### PR TITLE
Improve fastpass performance.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.jvmopts eol=lf

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Xss4m
+-Xms1G
+-Xmx4G
+-XX:ReservedCodeCacheSize=1024m
+-XX:+TieredCompilation
+-XX:+CMSClassUnloadingEnabled
+-Dfile.encoding=UTF-8

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ lazy val fastpass = project
     organization := "org.scalameta",
     name := "fastpass",
     scalaVersion := V.scala212,
+    fork := true,
     libraryDependencies ++= Seq(
       "com.geirsson" %% "metaconfig-core" % V.metaconfig,
       "io.get-coursier" % "interface" % V.coursierInterfaces,
@@ -100,6 +101,9 @@ lazy val fastpass = project
       "bloopVersion" -> V.bloop,
       "bloopNightlyVersion" -> V.bloop,
       "scala212" -> V.scala212
+    ),
+    mainClass.in(Compile) := Some(
+      "scala.meta.fastpass.Fastpass"
     ),
     mainClass.in(GraalVMNativeImage) := Some(
       "scala.meta.fastpass.Fastpass"

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/FastpassEnrichments.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/FastpassEnrichments.scala
@@ -14,7 +14,7 @@ import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
 import scala.util.control.NonFatal
 
-object FastpassEnrichments extends DecorateAsScala {
+object FastpassEnrichments extends DecorateAsScala with DecorateAsJava {
 
   implicit class XtensionStream[A](stream: java.util.stream.Stream[A]) {
     def asScala: Generator[A] = {

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -37,6 +37,7 @@ import java.nio.file.FileSystems
 import scala.annotation.tailrec
 import scala.meta.internal.fastpass.MD5
 import scala.meta.internal.fastpass.FastpassLogger
+import scala.annotation.switch
 
 object BloopPants {
   lazy val app: CliApp = CliApp(
@@ -108,7 +109,7 @@ object BloopPants {
       )
       val outputFilename = PantsConfiguration.outputFilename(args.targets)
       val outputFile = cacheDir.resolve(s"$outputFilename-export.json")
-      val bloopDir = args.out.resolve(".bloop")
+      val bloopDir = args.bloopDir
       if (Files.isSymbolicLink(bloopDir)) {
         Files.delete(bloopDir)
       }
@@ -189,9 +190,22 @@ object BloopPants {
     }
   }
 
-  private val nonAlphanumeric = "[^a-zA-Z0-9\\._]".r
   def makeReadableFilename(target: String): String = {
-    nonAlphanumeric.replaceAllIn(target, "-")
+    val out = new java.lang.StringBuilder(target.length())
+    var i = 0
+    while (i < target.length()) {
+      val ch = (target.charAt(i): @switch) match {
+        case '.' => '.'
+        case '_' => '_'
+        case ch =>
+          if (Character.isAlphabetic(ch)) ch
+          else if (Character.isDigit(ch)) ch
+          else '-'
+      }
+      out.append(ch)
+      i += 1
+    }
+    out.toString()
   }
   def makeJsonFilename(target: String): String = {
     makeReadableFilename(target) + ".json"
@@ -233,13 +247,15 @@ private class BloopPants(
     bloopDir: Path,
     export: PantsExport
 )(implicit ec: ExecutionContext) { self =>
+  val size = export.targets.valuesIterator.count(_.isTargetRoot)
+  val isLarge = size > 250
   def token: CancelChecker = args.token
   def workspace: Path = args.workspace
   def userTargets: List[String] = args.targets
   def cycles: Cycles = export.cycles
 
   private val scalaCompiler = "org.scala-lang:scala-compiler:"
-  private val transitiveClasspath = mutable.Map.empty[String, List[Path]]
+  private val transitiveClasspath = new ju.HashMap[String, List[Path]]().asScala
   private val isVisited = mutable.Set.empty[String]
   private val binaryDependencySources = mutable.Set.empty[Path]
 
@@ -271,7 +287,9 @@ private class BloopPants(
   private val jarPattern =
     FileSystems.getDefault().getPathMatcher("glob:**.jar")
   private val copiedJars = new ju.HashSet[Path]()
-  private val sourcesJars = new ju.HashSet[Path]()
+  private val sourcesJars = ju.Collections.newSetFromMap(
+    new ju.IdentityHashMap[PantsLibrary, java.lang.Boolean]
+  )
   private val immutableJars = mutable.Map.empty[Path, Path]
   val allScalaJars: List[Path] =
     export.scalaPlatform.compilerClasspath
@@ -282,7 +300,12 @@ private class BloopPants(
     token.checkCanceled()
     val projects = export.targets.valuesIterator
       .filter(_.isTargetRoot)
-      .map(toBloopProject)
+      .zipWithIndex
+      .map {
+        case (target, i) =>
+          printProgress(i)
+          toBloopProject(target)
+      }
       .toList
     copyImmutableJars()
     val sourceRoots = PantsConfiguration.sourceRoots(
@@ -360,6 +383,25 @@ private class BloopPants(
     new PantsExportResult(generatedProjects.size, export)
   }
 
+  val intervals = 20
+  val points = 100 / intervals
+  val isProgressPoint = 0
+    .until(size)
+    .by(size / (intervals - 1))
+    .zipWithIndex
+    .toMap
+    .updated(size - 1, intervals)
+  def printProgress(i: Int): Unit = {
+    if (isLarge) {
+      isProgressPoint.get(i).foreach { step =>
+        val hashes = "#" * step
+        val percentage = step * points
+        args.app.info(
+          f"$percentage%3s%% [$hashes%-20s] ${size - i - 1}%4s targets remaining"
+        )
+      }
+    }
+  }
   private def toBloopProject(target: PantsTarget): C.Project = {
 
     val baseDirectory: Path = target.baseDirectory(workspace)
@@ -394,63 +436,58 @@ private class BloopPants(
       if acyclicDependency.isTargetRoot
     } yield acyclicDependency.dependencyName
 
-    def libraries(extractor: PantsTarget => Seq[String]): List[PantsLibrary] =
-      for {
-        dependency <- target :: transitiveDependencies
-        libraryName <- extractor(dependency)
-        // The "$ORGANIZATION:$ARTIFACT" part of Maven library coordinates.
-        module = {
-          val colon = libraryName.lastIndexOf(':')
-          if (colon < 0) libraryName
-          else libraryName.substring(0, colon)
-        }
-        // Respect "excludes" setting in Pants BUILD files to exclude library dependencies.
-        if !target.excludes.contains(module)
-        library <- export.libraries.get(libraryName)
-      } yield library
-    val compileLibraries: List[PantsLibrary] = libraries(_.compileLibraries)
-    val runtimeLibraries: List[PantsLibrary] = libraries(_.runtimeLibraries)
+    val libraries = classpathLibraries(target, transitiveDependencies)
 
     def classpath(libraries: List[PantsLibrary]): List[Path] = {
-      val classpathEntries = new mutable.LinkedHashSet[Path]()
-      classpathEntries ++= (for {
-        dependency <- transitiveDependencies
-        if dependency.isTargetRoot
-        acyclicDependency = cycles.parents
-          .get(dependency.name)
-          .flatMap(export.targets.get)
-          .getOrElse(dependency)
-      } yield acyclicDependency.classesDir(bloopDir))
-      classpathEntries ++= libraries.iterator.flatMap(library =>
-        library.nonSources.map(path => toImmutableJar(library, path))
-      )
-      classpathEntries ++= allScalaJars
-      if (target.targetType.isTest) {
-        classpathEntries ++= testingFrameworkJars
+      val classpathEntries = new ju.HashSet[Path]
+      val result = mutable.ListBuffer.empty[Path]
+      for {
+        dependency <- transitiveDependencies.iterator
+      } {
+        if (dependency.isTargetRoot) {
+          val acyclicDependency = cycles.parents
+            .get(dependency.name)
+            .flatMap(export.targets.get)
+            .getOrElse(dependency)
+          classpathEntries.add(acyclicDependency.classesDir)
+        }
       }
-      classpathEntries.toList
+
+      for {
+        library <- libraries.iterator
+        path <- library.nonSources
+      } {
+        classpathEntries.add(toImmutableJar(library, path))
+      }
+      classpathEntries.addAll(allScalaJars.asJava)
+      if (target.targetType.isTest) {
+        classpathEntries.addAll(testingFrameworkJars.asJava)
+      }
+      classpathEntries.iterator.asScala.toList
     }
-    val compileClasspath = classpath(compileLibraries)
-    val runtimeClasspath = classpath(runtimeLibraries)
+    val compileClasspath = classpath(libraries.compile)
+    val runtimeClasspath = classpath(libraries.runtime)
 
     val resolution = Some(
       C.Resolution(
         (for {
-          library <- compileLibraries.iterator ++ runtimeLibraries.iterator
-          source <- library.sources
+          // NOTE(olafur): we don't include sources of runtime libraries
+          // to reduce the amount of sources.jar to index in IntelliJ.
+          library <- libraries.compile.iterator
           // NOTE(olafur): avoid sending the same *-sources.jar to reduce the
           // size of the Bloop JSON configs. Both IntelliJ and Metals only need each
           // jar to appear once.
-          if !sourcesJars.contains(source)
+          if !sourcesJars.contains(library)
+          source <- library.sources
         } yield {
-          sourcesJars.add(source)
+          sourcesJars.add(library)
           newSourceModule(source)
         }).toList
       )
     )
 
     val out: Path = bloopDir.resolve(target.directoryName)
-    val classesDir: Path = target.classesDir(bloopDir)
+    val classesDir = target.classesDir
     val javaHome: Option[Path] =
       target.platform.map(Paths.get(_))
 
@@ -504,6 +541,39 @@ private class BloopPants(
     )
   }
 
+  case class ClasspathLibraries(
+      compile: List[PantsLibrary],
+      runtime: List[PantsLibrary]
+  )
+  def classpathLibraries(
+      target: PantsTarget,
+      transitiveDependencies: List[PantsTarget]
+  ): ClasspathLibraries = {
+    val compile = mutable.ListBuffer.empty[PantsLibrary]
+    val runtime = mutable.ListBuffer.empty[PantsLibrary]
+    def visit(
+        out: mutable.ListBuffer[PantsLibrary],
+        libraryNames: Seq[String]
+    ): Unit = {
+      for {
+        libraryName <- libraryNames.iterator
+      } {
+        val library = export.librariesJava.get(libraryName)
+        // Respect "excludes" setting in Pants BUILD files to exclude library dependencies.
+        if (library != null && !target.excludes.contains(library.module)) {
+          out += library
+        }
+      }
+    }
+    for {
+      dependency <- (target :: transitiveDependencies).iterator
+    } {
+      visit(compile, dependency.compileLibraries)
+      visit(runtime, dependency.runtimeLibraries)
+    }
+    ClasspathLibraries(compile.toList, runtime.toList)
+  }
+
   // Returns a Bloop project that has no source code. This project only exists
   // to control for example how the project view is displayed in IntelliJ.
   private def toEmptyBloopProject(name: String, directory: Path): C.Project = {
@@ -538,8 +608,12 @@ private class BloopPants(
   }
 
   private def toImmutableJar(library: PantsLibrary, path: Path): Path = {
-    val filename = BloopPants.makeReadableFilename(library.name) + ".jar"
-    toImmutableJar(filename, path)
+    val fromCache = toCopyBuffer.get(path)
+    if (fromCache != null) fromCache
+    else {
+      val filename = BloopPants.makeReadableFilename(library.name) + ".jar"
+      toImmutableJar(filename, path)
+    }
   }
   private def toImmutableJar(filename: String, path: Path): Path = {
     // NOTE(olafur): Jars that live inside $WORKSPACE/.pants.d get overwritten
@@ -556,6 +630,7 @@ private class BloopPants(
         }
       )
     } else {
+      toCopyBuffer.put(path, path)
       path
     }
   }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Cycles.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Cycles.scala
@@ -10,7 +10,9 @@ case class Cycles(
     parents.getOrElse(target, target)
 }
 object Cycles {
-  def findConnectedComponents(targets: Map[String, PantsTarget]): Cycles = {
+  def findConnectedComponents(
+      targets: collection.Map[String, PantsTarget]
+  ): Cycles = {
     val graph = Graph.fromTargets(targets.values.toIndexedSeq)
     val ccs = Tarjans.fromGraph(graph.graph)
     val children = mutable.Map.empty[String, List[String]]

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Export.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Export.scala
@@ -19,6 +19,7 @@ case class Export(
     isRegenerate: Boolean = false,
     token: CancelChecker = () => ()
 ) {
+  def bloopDir = out.resolve(".bloop")
   def isSources: Boolean = !export.disableSources
   def isMergeTargetsInSameDirectory: Boolean =
     export.mergeTargetsInSameDirectory

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IdentityHashSet.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IdentityHashSet.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.fastpass.pantsbuild
+
+import java.{util => ju}
+
+class IdentityHashSet[T](
+    underlying: ju.Set[T] =
+      ju.Collections.newSetFromMap(new ju.IdentityHashMap[T, java.lang.Boolean])
+) {
+  def add(value: T) = underlying.add(value)
+  def contains(value: T) = underlying.contains(value)
+}

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExport.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExport.scala
@@ -92,11 +92,11 @@ object PantsExport {
       val compileLibraries: mutable.ArrayBuffer[String] = value
         .getOrElse(PantsKeys.compileLibraries, value(PantsKeys.libraries))
         .arr
-        .map(_.str)
+        .map(_.str.intern())
       val runtimeLibraries: mutable.ArrayBuffer[String] = value
         .getOrElse(PantsKeys.runtimeLibraries, value(PantsKeys.libraries))
         .arr
-        .map(_.str)
+        .map(_.str.intern())
       val isPantsTargetRoot = value(PantsKeys.isTargetRoot).bool
       val pantsTargetType =
         PantsTargetType(value(PantsKeys.pantsTargetType).str)
@@ -142,8 +142,9 @@ object PantsExport {
     val allLibraries = output.obj(PantsKeys.libraries).obj
     val libraries = new ju.HashMap[String, PantsLibrary]
     for {
-      (libraryName, valueObj) <- allLibraries.iterator
+      (libraryNameNonInterned, valueObj) <- allLibraries.iterator
     } {
+      val libraryName = libraryNameNonInterned.intern()
       // The "$ORGANIZATION:$ARTIFACT" part of Maven library coordinates.
       val module = {
         val colon = libraryName.lastIndexOf(':')
@@ -156,7 +157,10 @@ object PantsExport {
           if (Files.exists(path)) Some(key -> path)
           else None
       }
-      libraries.put(libraryName, PantsLibrary(libraryName, module, values))
+      libraries.put(
+        libraryName,
+        PantsLibrary(libraryName, module, values)
+      )
     }
 
     val cycles = Cycles.findConnectedComponents(targets.asScala)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsLibrary.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsLibrary.scala
@@ -4,12 +4,15 @@ import java.nio.file.Path
 
 case class PantsLibrary(
     name: String,
+    module: String,
     values: collection.Map[String, Path]
 ) {
   def default: Option[Path] = values.get("default")
   def sources: Option[Path] = values.get("sources")
-  def nonSources: Iterable[Path] = values.collect {
-    case (key, path) if key != "sources" =>
-      path
+  def nonSources: Iterator[Path] = {
+    values.iterator.collect {
+      case (key, path) if key != "sources" =>
+        path
+    }
   }
 }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsLibrary.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsLibrary.scala
@@ -9,10 +9,9 @@ case class PantsLibrary(
 ) {
   def default: Option[Path] = values.get("default")
   def sources: Option[Path] = values.get("sources")
-  def nonSources: Iterator[Path] = {
+  val nonSources: List[Path] =
     values.iterator.collect {
       case (key, path) if key != "sources" =>
         path
-    }
-  }
+    }.toList
 }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTarget.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTarget.scala
@@ -20,7 +20,9 @@ case class PantsTarget(
     roots: PantsRoots,
     scalacOptions: List[String],
     javacOptions: List[String],
-    extraJvmOptions: List[String]
+    extraJvmOptions: List[String],
+    directoryName: String,
+    classesDir: Path
 ) {
   def isGeneratedTarget: Boolean = name.startsWith(".pants.d")
   private val prefixedId = id.stripPrefix(".")
@@ -31,11 +33,8 @@ case class PantsTarget(
   def isTargetRoot: Boolean =
     isPantsTargetRoot &&
       pantsTargetType.isSupported
-  val directoryName: String = BloopPants.makeClassesDirFilename(id)
   def baseDirectory(workspace: Path): Path =
     PantsConfiguration
       .baseDirectory(AbsolutePath(workspace), name)
       .toNIO
-  def classesDir(bloopDir: Path): Path =
-    Files.createDirectories(bloopDir.resolve(directoryName).resolve("classes"))
 }


### PR DESCRIPTION
Previously, fastpass could take ~10 minutes to process a particularly
large number of Pants targets with large classpaths. Now, it takes ~60
seconds to process the same set of targets. I would like it to run
faster, but it's not a high priority since there are lower hanging
fruits (like optimizing Pants export-dep-as-jar which uses 5 minutes for
the same target set.

There is one change to the semantics, we no longer include sources of runtime dependencies for IDE indexing.