### PR TITLE
Treat missing "sources" field as "sources: true".

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/Project.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/Project.scala
@@ -66,8 +66,8 @@ object Project {
       json <- Try(ujson.read(root.bspJson.readText)).toOption
       targets <- json.obj.get("pantsTargets")
       sources = json.obj.get("sources") match {
-        case Some(Bool(true)) => true
-        case _ => false
+        case Some(Bool(bool)) => bool
+        case _ => true
       }
     } yield Project(
       common,


### PR DESCRIPTION
Previously, fastpass would infer "sources: false" for old BSP projects
with a missing "sources" field. This meant that users stopped seeing
3rdparty sources when upgrading to the latest fastpass. Now, fastpass
will infer "sources: true" instead when the "sources" field is missing.