### PR TITLE
Use LinkedHashSet to preserve classpath ordering

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -449,7 +449,7 @@ private class BloopPants(
       transitiveDependencies: collection.Seq[PantsTarget],
       libraries: mutable.ArrayBuffer[PantsLibrary]
   ): List[Path] = {
-    val classpathEntries = new ju.HashSet[Path]
+    val classpathEntries = new ju.LinkedHashSet[Path]
     val result = mutable.ListBuffer.empty[Path]
     for {
       dependency <- transitiveDependencies.iterator


### PR DESCRIPTION
Previously, the ordering of jars in the Bloop classpath was random since
we used `ju.HashSet` to construct the classpath.