### PR TITLE
Link Scalafmt config file immediately.

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -25,7 +25,6 @@ import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.fastpass.Fastpass
 import scala.meta.internal.fastpass.pantsbuild.commands.SharedCommand
 import scala.meta.internal.fastpass.pantsbuild.commands.SharedOptions
-import scala.meta.internal.fastpass.pantsbuild.commands.SwitchCommand
 
 object IntelliJ {
   def launch(project: Project, open: OpenOptions): Unit = {
@@ -67,7 +66,7 @@ object IntelliJ {
       coursierBinary: Option[Path] = None,
       exportResult: Option[PantsExportResult] = None
   ): Unit = {
-    SwitchCommand.runScalafmtSymlink(project, shared)
+    SharedCommand.runScalafmtSymlink(project, shared)
     val bspJson = project.root.bspJson.toNIO
     Files.createDirectories(bspJson.getParent)
     val coursier = coursierBinary.getOrElse(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -23,6 +23,9 @@ import ujson.Obj
 import ujson.Str
 import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.fastpass.Fastpass
+import scala.meta.internal.fastpass.pantsbuild.commands.SharedCommand
+import scala.meta.internal.fastpass.pantsbuild.commands.SharedOptions
+import scala.meta.internal.fastpass.pantsbuild.commands.SwitchCommand
 
 object IntelliJ {
   def launch(project: Project, open: OpenOptions): Unit = {
@@ -60,9 +63,11 @@ object IntelliJ {
   /** The .bsp/bloop.json file is necessary for IntelliJ to automatically import the project */
   def writeBsp(
       project: Project,
+      shared: SharedOptions,
       coursierBinary: Option[Path] = None,
       exportResult: Option[PantsExportResult] = None
   ): Unit = {
+    SwitchCommand.runScalafmtSymlink(project, shared)
     val bspJson = project.root.bspJson.toNIO
     Files.createDirectories(bspJson.getParent)
     val coursier = coursierBinary.getOrElse(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendCommand.scala
@@ -101,7 +101,7 @@ object AmendCommand extends Command[AmendOptions]("amend") {
     } else {
       val newProject = project.copy(targets = newTargets.toList)
       if (newTargets != project.targets) {
-        IntelliJ.writeBsp(newProject)
+        IntelliJ.writeBsp(newProject, amend.common)
         RefreshCommand.run(
           RefreshOptions(
             projects = amend.projects,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SharedCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SharedCommand.scala
@@ -61,6 +61,7 @@ object SharedCommand {
         case Success(exportResult) =>
           IntelliJ.writeBsp(
             export.project,
+            export.common,
             export.export.coursierBinary,
             exportResult
           )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SwitchCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SwitchCommand.scala
@@ -99,7 +99,15 @@ object SwitchCommand extends Command[SwitchOptions]("switch") {
       Files.deleteIfExists(workspaceBloop)
       Files.createSymbolicLink(workspaceBloop, outBloop)
     }
+    runScalafmtSymlink(project, common)
+  }
 
+  def runScalafmtSymlink(
+      project: Project,
+      common: SharedOptions
+  ): Unit = {
+    val workspace = common.workspace
+    val out = project.root.bspRoot.toNIO
     val inScalafmt = {
       var link = workspace.resolve(".scalafmt.conf")
       // Configuration file may be symbolic link.
@@ -117,6 +125,7 @@ object SwitchCommand extends Command[SwitchOptions]("switch") {
         Files.isSymbolicLink(outScalafmt)
       }) {
       Files.deleteIfExists(outScalafmt)
+      Files.createDirectories(outScalafmt.getParent())
       Files.createSymbolicLink(outScalafmt, inScalafmt)
     }
   }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SwitchCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SwitchCommand.scala
@@ -99,35 +99,7 @@ object SwitchCommand extends Command[SwitchOptions]("switch") {
       Files.deleteIfExists(workspaceBloop)
       Files.createSymbolicLink(workspaceBloop, outBloop)
     }
-    runScalafmtSymlink(project, common)
-  }
-
-  def runScalafmtSymlink(
-      project: Project,
-      common: SharedOptions
-  ): Unit = {
-    val workspace = common.workspace
-    val out = project.root.bspRoot.toNIO
-    val inScalafmt = {
-      var link = workspace.resolve(".scalafmt.conf")
-      // Configuration file may be symbolic link.
-      while (Files.isSymbolicLink(link)) {
-        link = Files.readSymbolicLink(link)
-      }
-      // Symbolic link may be relative to workspace directory.
-      if (link.isAbsolute()) link
-      else workspace.resolve(link)
-    }
-    val outScalafmt = out.resolve(".scalafmt.conf")
-    if (!out.startsWith(workspace) &&
-      Files.exists(inScalafmt) && {
-        !Files.exists(outScalafmt) ||
-        Files.isSymbolicLink(outScalafmt)
-      }) {
-      Files.deleteIfExists(outScalafmt)
-      Files.createDirectories(outScalafmt.getParent())
-      Files.createSymbolicLink(outScalafmt, inScalafmt)
-    }
+    SharedCommand.runScalafmtSymlink(project, common)
   }
 
   private def warnBloopDirectory(


### PR DESCRIPTION
Previously, Fastpass waited for the Pants refresh to complete before
linking the `.scalafmt.conf` file. Now, the Scalafmt config file is
linked immediately before launching IntelliJ to ensure that users always
have a `.scalafmt.conf` file even if the Pants refresh has not
completed.