### PR TITLE
Implement on-demand sources mode

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -150,9 +150,9 @@ object BloopPants {
       outputFile: Path
   )(implicit ec: ExecutionContext): Unit = {
     val noInternalSources =
-      if (args.export.disableSources || args.export.onDemandSources) "no-"
+      if (args.sources.isOff || args.sources.isOnDemand) "no-"
       else ""
-    val no3rdPartySources = if (args.export.disableSources) "no-" else ""
+    val no3rdPartySources = if (args.sources.isOff) "no-" else ""
 
     val command = List[String](
       args.workspace.resolve("pants").toString(),
@@ -479,7 +479,7 @@ private class BloopPants(
   }
 
   def getResolution(libraries: ClasspathLibraries): Option[C.Resolution] = {
-    if (args.export.onDemandSources) {
+    if (args.sources.isOnDemand) {
       None
     } else {
       Some(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Export.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Export.scala
@@ -19,6 +19,7 @@ case class Export(
     isRegenerate: Boolean = false,
     token: CancelChecker = () => ()
 ) {
+  val sources = export.sources.toNonDefaultWithFallback(project.sources)
   def bloopDir = out.resolve(".bloop")
   def isMergeTargetsInSameDirectory: Boolean =
     export.mergeTargetsInSameDirectory

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Export.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/Export.scala
@@ -20,7 +20,6 @@ case class Export(
     token: CancelChecker = () => ()
 ) {
   def bloopDir = out.resolve(".bloop")
-  def isSources: Boolean = !export.disableSources
   def isMergeTargetsInSameDirectory: Boolean =
     export.mergeTargetsInSameDirectory
   def root = project.root

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -74,7 +74,7 @@ object IntelliJ {
     newJson("bspVersion") = V.bspVersion
     newJson("languages") = List[String]("scala", "java")
     newJson("argv") = List[String](
-      coursier.toString(),
+      coursier.toString,
       "launch",
       s"ch.epfl.scala:bloop-launcher-core_2.12:${V.bloopNightlyVersion}",
       "--ttl",
@@ -82,7 +82,9 @@ object IntelliJ {
       "--",
       V.bloopVersion
     )
-    newJson("sources") = project.sources
+    project.sources.foreach(sourcesMode =>
+      newJson("sources") = sourcesMode.toString
+    )
     newJson("pantsTargets") = project.targets
     newJson("fastpassVersion") = V.fastpassVersion
     newJson("fastpassProjectName") = project.name

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -82,9 +82,7 @@ object IntelliJ {
       "--",
       V.bloopVersion
     )
-    project.sources.foreach(sourcesMode =>
-      newJson("sources") = sourcesMode.toString
-    )
+    newJson("sources") = project.sources.toNonDefault.toString
     newJson("pantsTargets") = project.targets
     newJson("fastpassVersion") = V.fastpassVersion
     newJson("fastpassProjectName") = project.name

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
@@ -52,7 +52,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
           name,
           create.common,
           create.targets,
-          sources = !create.export.disableSources
+          sources = Some(create.export.sourcesMode)
         )
         SharedCommand.interpretExport(
           Export(project, create.open, app).copy(export = create.export)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
@@ -52,7 +52,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
           name,
           create.common,
           create.targets,
-          sources = Some(create.export.sourcesMode)
+          sources = create.export.sources.toNonDefault
         )
         SharedCommand.interpretExport(
           Export(project, create.open, app).copy(export = create.export)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/ExportOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/ExportOptions.scala
@@ -7,14 +7,11 @@ import java.nio.file.Path
 
 case class ExportOptions(
     @Description(
-      "Disable downloading of -sources.jar for 3rd party dependencies."
+      "Control sources. Use 'off' to disable downloading sources for 3rd party libraries. " +
+        "Use 'on' to download and link te sources automatically. " +
+        "Use 'on-demand' to download sources and allow linking them later."
     )
-    disableSources: Boolean = false,
-    @Description(
-      "Enable downloading of sources for 3rdparty dependencies. This flag has no impact unless " +
-        "downloading of sources has been disabled for this project via the --disable-sources flag."
-    )
-    enableSources: Boolean = false,
+    sources: Option[String] = None,
     @Description(
       "The path to the coursier binary." +
         "If unspecified, coursier will be downloaded automatically."
@@ -27,6 +24,13 @@ case class ExportOptions(
     mergeTargetsInSameDirectory: Boolean = false
 ) {
   def canBloopExit: Boolean = !noBloopExit
+
+  def disableSources: Boolean = sourcesMode == SourcesMode.Off
+  def enableSources: Boolean = sourcesMode == SourcesMode.On
+  def onDemandSources: Boolean = sourcesMode == SourcesMode.OnDemand
+
+  lazy val sourcesMode: SourcesMode =
+    sources.map(SourcesMode.parse).getOrElse(SourcesMode.On)
 }
 
 object ExportOptions {

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/ExportOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/ExportOptions.scala
@@ -11,7 +11,7 @@ case class ExportOptions(
         "Use 'on' to download and link te sources automatically. " +
         "Use 'on-demand' to download sources and allow linking them later."
     )
-    sources: Option[String] = None,
+    sources: SourcesMode = SourcesMode.Default,
     @Description(
       "The path to the coursier binary." +
         "If unspecified, coursier will be downloaded automatically."
@@ -24,13 +24,6 @@ case class ExportOptions(
     mergeTargetsInSameDirectory: Boolean = false
 ) {
   def canBloopExit: Boolean = !noBloopExit
-
-  def disableSources: Boolean = sourcesMode == SourcesMode.Off
-  def enableSources: Boolean = sourcesMode == SourcesMode.On
-  def onDemandSources: Boolean = sourcesMode == SourcesMode.OnDemand
-
-  lazy val sourcesMode: SourcesMode =
-    sources.map(SourcesMode.parse).getOrElse(SourcesMode.On)
 }
 
 object ExportOptions {

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/Project.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/Project.scala
@@ -4,14 +4,14 @@ import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.internal.fastpass.pantsbuild.PantsConfiguration
 import scala.meta.io.AbsolutePath
 import scala.util.Try
-import ujson.Bool
+import ujson.Str
 
 case class Project(
     common: SharedOptions,
     name: String,
     targets: List[String],
     root: ProjectRoot,
-    sources: Boolean
+    sources: Option[SourcesMode]
 ) {
   val fuzzyName: String = PantsConfiguration.outputFilename(name)
   def matchesName(query: String): Boolean =
@@ -24,7 +24,7 @@ object Project {
       name: String,
       common: SharedOptions,
       targets: List[String],
-      sources: Boolean
+      sources: Option[SourcesMode]
   ): Project = {
     Project(
       common,
@@ -66,8 +66,8 @@ object Project {
       json <- Try(ujson.read(root.bspJson.readText)).toOption
       targets <- json.obj.get("pantsTargets")
       sources = json.obj.get("sources") match {
-        case Some(Bool(bool)) => bool
-        case _ => true
+        case Some(Str(str)) => Some(SourcesMode.parse(str))
+        case _ => None
       }
     } yield Project(
       common,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/RefreshCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/RefreshCommand.scala
@@ -29,9 +29,7 @@ object RefreshCommand extends Command[RefreshOptions]("refresh") {
         case Some(project) =>
           SharedCommand.interpretExport(
             Export(project, refresh.open, app).copy(
-              export = refresh.export.copy(sources =
-                project.sources.map(_.toString).orElse(refresh.export.sources)
-              ),
+              export = refresh.export.copy(sources = refresh.export.sources),
               isCache = refresh.update
             )
           )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/RefreshCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/RefreshCommand.scala
@@ -29,10 +29,8 @@ object RefreshCommand extends Command[RefreshOptions]("refresh") {
         case Some(project) =>
           SharedCommand.interpretExport(
             Export(project, refresh.open, app).copy(
-              export = refresh.export.copy(
-                disableSources =
-                  (!project.sources || refresh.export.disableSources) &&
-                    !refresh.export.enableSources
+              export = refresh.export.copy(sources =
+                project.sources.map(_.toString).orElse(refresh.export.sources)
               ),
               isCache = refresh.update
             )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SourcesMode.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SourcesMode.scala
@@ -1,19 +1,42 @@
 package scala.meta.internal.fastpass.pantsbuild.commands
 
-sealed abstract class SourcesMode(override val toString: String)
+import metaconfig.Configured
+import metaconfig.Conf
+
+sealed abstract class SourcesMode(override val toString: String) {
+  def isOff: Boolean = this == SourcesMode.Off
+  def isOn: Boolean = this == SourcesMode.On
+  def isOnDemand: Boolean = this == SourcesMode.OnDemand
+  def isDefault: Boolean = this == SourcesMode.Default
+  def toNonDefault: SourcesMode =
+    if (isDefault) SourcesMode.On
+    else this
+  def toNonDefaultWithFallback(fallback: SourcesMode): SourcesMode =
+    if (isDefault) fallback.toNonDefault
+    else toNonDefault
+}
 
 object SourcesMode {
   case object On extends SourcesMode("on")
   case object Off extends SourcesMode("off")
+  case object Default extends SourcesMode("default")
   case object OnDemand extends SourcesMode("on-demand")
 
-  def parse(s: String): SourcesMode = s match {
-    case On.toString | "yes" | "true" | "enabled" => On
-    case Off.toString | "no" | "false" | "disabled" => Off
-    case OnDemand.toString => OnDemand
-    case _ =>
-      throw new RuntimeException(
-        s"Invalid source mode $s. Use: 'on', 'off' or 'on-demand'"
-      )
-  }
+  implicit lazy val encoder: metaconfig.ConfEncoder[SourcesMode] =
+    metaconfig.ConfEncoder.StringEncoder.contramap[SourcesMode](_.toString)
+  implicit lazy val decoder: metaconfig.ConfDecoder[SourcesMode] =
+    metaconfig.ConfDecoder.instanceExpect(s"$On|$Off|$OnDemand") {
+      case Conf.Str(On.toString | "yes" | "true" | "enabled") |
+          Conf.Bool(true) =>
+        Configured.ok(On)
+      case Conf.Str(Off.toString | "no" | "false" | "disabled") |
+          Conf.Bool(false) =>
+        Configured.ok(Off)
+      case Conf.Str(OnDemand.toString) => Configured.ok(OnDemand)
+      case Conf.Str(Default.toString) => Configured.ok(Default)
+      case other =>
+        Configured.error(
+          s"Invalid --sources value '$other'. To fix this problem, use 'on', 'off' or 'on-demand'"
+        )
+    }
 }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SourcesMode.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SourcesMode.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.fastpass.pantsbuild.commands
+
+sealed abstract class SourcesMode(override val toString: String)
+
+object SourcesMode {
+  case object On extends SourcesMode("on")
+  case object Off extends SourcesMode("off")
+  case object OnDemand extends SourcesMode("on-demand")
+
+  def parse(s: String): SourcesMode = s match {
+    case On.toString | "yes" | "true" | "enabled" => On
+    case Off.toString | "no" | "false" | "disabled" => Off
+    case OnDemand.toString => OnDemand
+    case _ =>
+      throw new RuntimeException(
+        s"Invalid source mode $s. Use: 'on', 'off' or 'on-demand'"
+      )
+  }
+}


### PR DESCRIPTION
This PR sets up 3 modes for preparing sources through --sources=on|off|on-demand flag.
* `on` will fetch sources jars for 3rd party dependencies and generate source jars for internal dependencies and put them in bloop
* `off` will not fetch or generate any source jars
* `on-demand` will fetch 3rd party source jars and put them in `libraries.json` and will not generate any jars for internal source dependencies

Currently I made `on` the default as it used to be.