### PR TITLE
Ignore blank lines when amending project targets

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendCommand.scala
@@ -78,8 +78,9 @@ object AmendCommand extends Command[AmendOptions]("amend") {
         .asScala
         .flatMap { line =>
           if (line.startsWith("#")) Nil
-          else line.split(" ").toList
+          else line.trim.split("\\s").toList
         }
+        .filterNot(_.isEmpty())
         .toList
       Files.deleteIfExists(tmp)
       Some(newTargets)


### PR DESCRIPTION
Previously, inputting blank lines into `fastpass amend` would cause blank-named targets to be passed onto Pants, resulting in `ERROR: Build graph construction failed: ExecutionError 1 Exception encountered:  ResolveError: "" was not found in namespace ""`

This change removes such blank lines from being considered as new "targets". 