### PR TITLE
Use target base for resources

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -567,7 +567,9 @@ private class BloopPants(
     val resources: Option[List[Path]] =
       if (!target.targetType.isResourceOrTestResource) None
       else {
-        Some(List(baseDirectory))
+        target.targetBase.map { targetBase =>
+          List(workspace.resolve(targetBase))
+        }
       }
 
     val sourceRoots = target.targetBase.map { targetBase =>


### PR DESCRIPTION
Previously, resources were relativized by the the base directory (where
    BUILD file exists), which is incorrect resulting in test crashes
that load resources using a relative path. Now, we relativize resources
by the "target base", which is usually the nearest enclosing "resources"
directory. This fixes the issues related to loading relative resources.