### PR TITLE
Filter out `jvm_app` targets

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTargetType.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTargetType.scala
@@ -26,8 +26,9 @@ case class PantsTargetType(value: String) {
 
 object PantsTargetType {
   private val unsupportedTargetType = Set(
-    "files", "page", "python_binary", "python_tests", "python_library",
-    "python3_binary", "python23_library", "python_requirement_library",
-    "ruby_thrift_library", "python_thrift_library", "target"
+    "files", "jvm_app", "page", "python_binary", "python_tests",
+    "python_library", "python3_binary", "python23_library",
+    "python_requirement_library", "ruby_thrift_library",
+    "python_thrift_library", "target"
   )
 }


### PR DESCRIPTION
Previously, Fastpass would create Bloop config files for `jvm_app`
targets. These targets are just wrapper around binary targets, which
will copy the result of the binary target in a file tree, and add the
"bundled" files.

In the Bloop config files that would be generated, the bundled files
were considered as source files, which could produce compilation errors.