### PR TITLE
Downgrade to GraalVM 20.0.0

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v6
         with:
-          java-version: graalvm@20.1.0
+          java-version: graalvm@20.0.0
       - run: git fetch --tags || true
       - run: gu install native-image
       - run: sbt native-image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 First, install [Jabba](https://github.com/shyiko/jabba).
 
-Next, install GraalVM 20.1.0
+Next, install GraalVM 20.0.0
 ```
-jabba install graalvm@20.1.0
+jabba install graalvm@20.0.0
 ```
 
 Next, run `sbt native-image`.

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val fastpass = project
           .resolve(".jabba")
           .resolve("bin")
           .resolve("jabba")
-        val home = s"$jabba which --home graalvm@20.1.0".!!.trim()
+        val home = s"$jabba which --home graalvm@20.0.0".!!.trim()
         Paths.get(home).resolve("bin").resolve("native-image").toString
       }.getOrElse(old)
     },

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -847,7 +847,9 @@ private class BloopPants(
         .map(_.toPath())
         .toList
     } catch {
-      case NonFatal(_) => Nil
+      case NonFatal(e) =>
+        scribe.warn(s"Couldn't resolve dependency `$dep`", e)
+        Nil
     }
 
 }


### PR DESCRIPTION
Previously, the generated Bloop configuration file of test targets would
not include the dependency on `org.scalameta:junit-interface`, because
the resolution would fail under GraalVM 20.1.0 with the following error:

```
com.oracle.svm.core.jdk.UnsupportedFeatureError: Invoke with
MethodHandle argument could not be reduced to at most a single call or
single field access. The method handle must be a compile time constant,
e.g., be loaded from a `static final` field. Method that contains the
method handle invocation:
java.lang.invoke.LambdaForm$MH/2143945824.invoke_MT(Object, Object)
```

This error doesn't happen with previous version of GraalVM.