### PR TITLE
Correctly relativize paths in internal sources.jar

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -454,7 +454,7 @@ private class BloopPants(
     val result = new ConcurrentHashMap[Path, Path]
     resolutionTargets.stream().parallel().forEach { target =>
       target.targetBase.foreach { targetBase =>
-        val sourceRoot = workspace.resolve(targetBase)
+        val sourceRoot = AbsolutePath(workspace).resolve(targetBase)
         val sources = target.internalSourcesJar
         Files.deleteIfExists(sources)
         FileIO.withJarFileSystem(
@@ -463,11 +463,10 @@ private class BloopPants(
           close = true
         ) { root =>
           val jars = new SourcesJarBuilder(export, root.toNIO)
-          val base = workspace.resolve(targetBase)
           getSources(target)
             .foreach(dir => jars.expandDirectory(AbsolutePath(dir), sourceRoot))
           getSourcesGlobs(target, target.baseDirectory).iterator.flatten
-            .foreach(glob => jars.expandGlob(glob, base))
+            .foreach(glob => jars.expandGlob(glob, sourceRoot))
         }
         toImmutableJars(target).headOption.foreach { default =>
           result.put(default, sources)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/SourcesJarBuilder.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/SourcesJarBuilder.scala
@@ -43,9 +43,8 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
 
   def expandDirectory(
       dir: AbsolutePath,
-      relativizeBy: Path
+      relativizeBy: AbsolutePath
   ): Unit = {
-    val root = AbsolutePath(relativizeBy)
     Files.walkFileTree(
       dir.toNIO,
       java.util.EnumSet.of(FileVisitOption.FOLLOW_LINKS),
@@ -63,7 +62,7 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
         ): FileVisitResult = {
           write(
             AbsolutePath(file),
-            AbsolutePath(file).toRelative(root)
+            AbsolutePath(file).toRelative(relativizeBy)
           )
           FileVisitResult.CONTINUE
         }
@@ -71,7 +70,7 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
     )
   }
 
-  def expandGlob(glob: SourcesGlobs, baseDir: Path): Unit = {
+  def expandGlob(glob: SourcesGlobs, relativizeBy: AbsolutePath): Unit = {
     val fs = FileSystems.getDefault()
     val includes = glob.includes.map(fs.getPathMatcher)
     val excludes = glob.excludes.map(fs.getPathMatcher)
@@ -106,7 +105,7 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
           if (matches(file)) {
             write(
               AbsolutePath(file),
-              AbsolutePath(file).toRelative(AbsolutePath(glob.directory))
+              AbsolutePath(file).toRelative(relativizeBy)
             )
           }
           FileVisitResult.CONTINUE


### PR DESCRIPTION
Previously, we always relativized paths by the base directory of a
target. Now we relativize by the target base instead.

This change fixes a bug related to navigation for Java sources.