### PR TITLE
Fix bug that creates redundant project-root projects

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -454,7 +454,7 @@ private class BloopPants(
     val result = new ConcurrentHashMap[Path, Path]
     resolutionTargets.stream().parallel().forEach { target =>
       target.targetBase.foreach { targetBase =>
-        val sourceRoot = workspace.resolve(targetBase)
+        val sourceRoot = AbsolutePath(workspace).resolve(targetBase)
         val sources = target.internalSourcesJar
         Files.deleteIfExists(sources)
         FileIO.withJarFileSystem(
@@ -463,11 +463,10 @@ private class BloopPants(
           close = true
         ) { root =>
           val jars = new SourcesJarBuilder(export, root.toNIO)
-          val base = workspace.resolve(targetBase)
           getSources(target)
             .foreach(dir => jars.expandDirectory(AbsolutePath(dir), sourceRoot))
           getSourcesGlobs(target, target.baseDirectory).iterator.flatten
-            .foreach(glob => jars.expandGlob(glob, base))
+            .foreach(glob => jars.expandGlob(glob, sourceRoot))
         }
         toImmutableJars(target).headOption.foreach { default =>
           result.put(default, sources)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -327,7 +327,7 @@ private class BloopPants(
       args.targets
     )
     val isBaseDirectory =
-      projects.iterator.filter(_.sources.nonEmpty).map(_.directory).toSet
+      projects.iterator.filter(_.sourcesGlobs.nonEmpty).map(_.directory).toSet
     // NOTE(olafur): generate synthetic projects to improve the file tree view
     // in IntelliJ. Details: https://github.com/olafurpg/intellij-bsp-pants/issues/7
     val syntheticProjects: List[C.Project] = sourceRoots.flatMap { root =>

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/SourcesJarBuilder.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/SourcesJarBuilder.scala
@@ -43,9 +43,8 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
 
   def expandDirectory(
       dir: AbsolutePath,
-      relativizeBy: Path
+      relativizeBy: AbsolutePath
   ): Unit = {
-    val root = AbsolutePath(relativizeBy)
     Files.walkFileTree(
       dir.toNIO,
       java.util.EnumSet.of(FileVisitOption.FOLLOW_LINKS),
@@ -63,7 +62,7 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
         ): FileVisitResult = {
           write(
             AbsolutePath(file),
-            AbsolutePath(file).toRelative(root)
+            AbsolutePath(file).toRelative(relativizeBy)
           )
           FileVisitResult.CONTINUE
         }
@@ -71,7 +70,7 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
     )
   }
 
-  def expandGlob(glob: SourcesGlobs, baseDir: Path): Unit = {
+  def expandGlob(glob: SourcesGlobs, relativizeBy: AbsolutePath): Unit = {
     val fs = FileSystems.getDefault()
     val includes = glob.includes.map(fs.getPathMatcher)
     val excludes = glob.excludes.map(fs.getPathMatcher)
@@ -106,7 +105,7 @@ class SourcesJarBuilder(export: PantsExport, root: Path) {
           if (matches(file)) {
             write(
               AbsolutePath(file),
-              AbsolutePath(file).toRelative(AbsolutePath(glob.directory))
+              AbsolutePath(file).toRelative(relativizeBy)
             )
           }
           FileVisitResult.CONTINUE

--- a/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
+++ b/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
@@ -77,7 +77,7 @@ class BloopPantsSuite extends FastpassSuite {
       )
       .succeeds
     val projects0 = workspace.projects()
-    assertEquals(projects0.keys, Set("c:c", "c-project-root"))
+    assertEquals(projects0.keys, Set("c:c"))
     projects0("c:c")
       .doesntHaveBinaryOnCompileClasspath("a.a.jar")
       .hasBinaryOnCompileClasspath("b.b.jar")
@@ -90,7 +90,7 @@ class BloopPantsSuite extends FastpassSuite {
     val projects1 = workspace.projects()
     assertEquals(
       projects1.keys,
-      Set("b:b", "b-project-root", "c:c", "c-project-root")
+      Set("b:b", "c:c")
     )
     projects1("b:b")
       .hasBinaryOnCompileClasspath("a.a.jar")
@@ -107,8 +107,7 @@ class BloopPantsSuite extends FastpassSuite {
     val projects2 = workspace.projects()
     assertEquals(
       projects2.keys,
-      Set("a:a", "a-project-root", "b:b", "b-project-root", "c:c",
-        "c-project-root")
+      Set("a:a", "b:b", "c:c")
     )
     projects2("b:b")
       .hasProjectOnCompileClasspath(projects2("a:a"))
@@ -195,7 +194,7 @@ class BloopPantsSuite extends FastpassSuite {
       )
       .succeeds
     val projects0 = workspace.projects()
-    assertEquals(projects0.keys, Set("app-project-root", "app:my-binary"))
+    assertEquals(projects0.keys, Set("app:my-binary"))
     projects0("app:my-binary")
       .hasBinaryOnCompileClasspath("libs.my-library.jar")
       .hasBinaryOnRuntimeClasspath("libs.my-library.jar")
@@ -209,9 +208,7 @@ class BloopPantsSuite extends FastpassSuite {
     assertEquals(
       projects1.keys,
       Set(
-        "app-project-root",
         "app:my-binary",
-        "libs-project-root",
         "libs:my-library",
         "libs:scalacheck"
       )


### PR DESCRIPTION
Previously, fastpass created a synthetic `*-project-root` project
for all projects because it used `.sources` to detect base directories
and fastpass only uses `sourcesGlobs` now. Now we generate
`*-project-root` projects based on `sourcesGlobs` instead.