### PR TITLE
Read `main_class` from `export-fastpass` output

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -597,7 +597,7 @@ private class BloopPants(
               s"-Duser.dir=$workspace"
             ) ++ extraJvmOptions
           ),
-          None,
+          target.mainClass,
           Some(runtimeClasspath),
           None
         )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExport.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExport.scala
@@ -129,7 +129,8 @@ object PantsExport {
         strictDeps = asBoolean(value, PantsKeys.strictDeps),
         exports = asStringList(value, PantsKeys.exports).toSet,
         scope = PantsScope.fromJson(value),
-        targetBase = value.get(PantsKeys.target_base).map(_.str)
+        targetBase = value.get(PantsKeys.target_base).map(_.str),
+        mainClass = value.get(PantsKeys.main_class).map(_.str)
       )
       targets.put(name, target)
     }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsKeys.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsKeys.scala
@@ -33,4 +33,5 @@ object PantsKeys {
   val exports = "exports"
   val scope = "scope"
   val target_base = "target_base"
+  val main_class = "main_class"
 }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTarget.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTarget.scala
@@ -28,7 +28,8 @@ class PantsTarget(
     val isSynthetic: Boolean,
     val exports: Set[String],
     val scope: PantsScope,
-    val targetBase: Option[String]
+    val targetBase: Option[String],
+    val mainClass: Option[String]
 ) {
   require(
     !classesDir.getFileName().toString().endsWith(".json"),


### PR DESCRIPTION
Previously, Fastpass couldn't tell Bloop the name of a target's main
class, because the output from `export-fastpass` didn't include this
information. Now that it is available, Fastpass can read it and include
it in the generated Bloop configuration.