### PR TITLE
Fill 'argvExit' field in .bsp/bloop.json

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -115,9 +115,12 @@ object IntelliJ {
       RefreshCommand.name,
       "--workspace",
       project.common.workspace.toString,
-      "--no-bloop-exit",
+      "--no-bloop-exit"
+    ) ++
+      shared.pants
+        .map(path => List("--pants", path.toString))
+        .getOrElse(List.empty) :+
       project.name
-    )
 
     val workspace = scala.meta.io.AbsolutePath(project.common.workspace)
     val props = Property.fromFile(workspace)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -87,6 +87,13 @@ object IntelliJ {
       "--",
       V.bloopVersion
     )
+    newJson("argvExit") = List[String](
+      coursier.toString,
+      "launch",
+      s"bloop:${V.bloopVersion}",
+      "--",
+      "exit"
+    )
     newJson("sources") = project.sources.toNonDefault.toString
     newJson("strictDeps") = project.strictDeps.toNonDefault.toString
     newJson("pantsTargets") = project.targets


### PR DESCRIPTION
2 commmits included in this PR

#### Fill 'argvExit' field in .bsp/bloop.json

It's used by the IDE to terminate BSP server


#### Take custom pants path into account in refreshCommand 

If the project was generated with custom pants path, refresh
probably should be done similarly.