### PR TITLE
Support repeating `--new-targets` argument

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendCommand.scala
@@ -34,29 +34,26 @@ object AmendCommand extends Command[AmendOptions]("amend") {
       amend.common,
       app
     ) { project =>
-      amend.targetsToAmend match {
-        case Some(value) => {
-          runAmend(amend, app, project, value)
-        }
-        case None => {
-          Option(System.getenv("EDITOR")) match {
-            case None =>
-              app.error(
-                "the $EDITOR environment variable is undefined. " +
-                  "To fix this problem, run `export EDITOR=vim` " +
-                  "(or `export EDITOR='code -w'` for VS Code) " +
-                  "and try again"
-              )
-              1
-            case Some(editor) =>
-              val list = getTargetsListViaEditor(
-                amend,
-                app,
-                editor,
-                project
-              )
-              list.map(runAmend(amend, app, project, _)).getOrElse(1)
-          }
+      if (amend.targetsToAmend.nonEmpty) {
+        runAmend(amend, app, project, amend.targetsToAmend)
+      } else {
+        Option(System.getenv("EDITOR")) match {
+          case None =>
+            app.error(
+              "the $EDITOR environment variable is undefined. " +
+                "To fix this problem, run `export EDITOR=vim` " +
+                "(or `export EDITOR='code -w'` for VS Code) " +
+                "and try again"
+            )
+            1
+          case Some(editor) =>
+            val list = getTargetsListViaEditor(
+              amend,
+              app,
+              editor,
+              project
+            )
+            list.map(runAmend(amend, app, project, _)).getOrElse(1)
         }
       }
 

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/AmendOptions.scala
@@ -13,13 +13,13 @@ case class AmendOptions(
         "to use for this project. If not specified, opens " +
         "$EDITOR to manually enter the new list of target specs."
     )
-    newTargets: Option[String] = None,
+    newTargets: List[String] = Nil,
     @Inline open: OpenOptions = OpenOptions(),
     @Inline export: ExportOptions = ExportOptions(),
     @Inline common: SharedOptions = SharedOptions()
 ) {
-  def targetsToAmend: Option[List[String]] =
-    newTargets.map(_.split(",")).map(_.toList)
+  def targetsToAmend: List[String] =
+    newTargets.flatMap(_.split(","))
 }
 
 object AmendOptions {


### PR DESCRIPTION
Previously, the following command only picked up the last
`--new-targets` value and ignored the leading values.
```
fastpass amend foobar --new-targets a:: --new-targets b::
```
Now, it picks up both `a::` and `b::`.