### PR TITLE
Allow forward slash to manually provided name argument.

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateOptions.scala
@@ -25,9 +25,7 @@ case class CreateOptions(
     @Hidden() @Inline common: SharedOptions = SharedOptions.default
 ) {
   def actualName: String =
-    name.getOrElse {
-      PantsConfiguration.outputFilename(targets)
-    }
+    PantsConfiguration.outputFilename(name.map(List(_)).getOrElse(targets))
 }
 
 object CreateOptions {

--- a/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
+++ b/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
@@ -37,7 +37,9 @@ class BloopPantsSuite extends FastpassSuite {
                                  |  println(core.Lib.greeting)
                                  |}
                                  |""".stripMargin)
-    workspace.run("create" :: "::" :: Nil).succeeds
+    workspace
+      .run("create" :: "--name" :: "example/project" :: "::" :: Nil)
+      .succeeds
     val projects = workspace.projects()
     assertEquals(projects.keys, Set("-project-root", "core:core", "src:src"))
 


### PR DESCRIPTION
Previously, it was not possible to run `fastpass create --name foo/bar`
because the slash in the name got translated into nested directories.
Now, Fastpass escapes the slash character so that the project gets the
name `foo.bar`.