### PR TITLE
Upgrade to latest GraalVM on Java 11

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v6
         with:
-          java-version: graalvm@20.0.0
+          java-version: graalvm-ce-java11@20.1.0
       - run: git fetch --tags || true
       - run: gu install native-image
       - run: sbt native-image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 First, install [Jabba](https://github.com/shyiko/jabba).
 
-Next, install GraalVM 20.0.0
+Next, install GraalVM 20.1.0
 ```
-jabba install graalvm@20.0.0
+jabba install graalvm-ce-java11@20.1.0
 ```
 
 Next, run `sbt native-image`.

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,7 @@ lazy val fastpass = project
           .resolve(".jabba")
           .resolve("bin")
           .resolve("jabba")
-        val home = s"$jabba which --home graalvm@20.0.0".!!.trim()
+        val home = s"$jabba which --home graalvm-ce-java11@20.1.0".!!.trim()
         Paths.get(home).resolve("bin").resolve("native-image").toString
       }.getOrElse(old)
     },
@@ -172,7 +172,6 @@ lazy val fastpass = project
         Keys.sourceDirectory.in(Compile).value./("graal")./("reflection.json")
       assert(reflectionFile.exists, "no such file: " + reflectionFile)
       List(
-        "-H:+ReportUnsupportedElementsAtRuntime",
         "--initialize-at-build-time",
         "--initialize-at-run-time=scala.meta.internal.fastpass,metaconfig",
         "--no-server",


### PR DESCRIPTION
Prevously, Fastpass was using an older version of GraalVM on Java 8.
This version had issues with `scala.runtime.Statics`, which resulted in
Fastpass failing to resolve `junit-interface` with Coursier, and forced
us to report unsupported features at runtime only.

The latest version of GraalVM on Java 11 let's us report unsupported
features at build time, and appears to work better with Coursier.