### PR TITLE
Remove custom VS Code settings.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ lazy val V = new {
   val metaconfig = "0.9.10"
   val scalameta = "4.3.10"
   val bsp = "2.0.0-M4+10-61e61e87"
-  val metals = "0.9.0"
   val munit = "0.7.7"
 }
 
@@ -140,7 +139,6 @@ lazy val fastpass = project
     ),
     buildInfoPackage := "scala.meta.internal.fastpass",
     buildInfoKeys := Seq[BuildInfoKey](
-      "metalsVersion" -> V.metals,
       "fastpassVersion" -> version.value,
       "bspVersion" -> V.bsp,
       "bloopVersion" -> V.bloop,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/VSCode.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/VSCode.scala
@@ -7,8 +7,6 @@ import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.internal.fastpass.pantsbuild.commands.Project
 import scala.meta.io.AbsolutePath
 
-import ujson.Obj
-
 object VSCode {
   def launch(project: Project): Unit =
     try {

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/VSCode.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/VSCode.scala
@@ -3,26 +3,15 @@ package scala.meta.internal.fastpass.pantsbuild
 import scala.sys.process._
 import scala.util.control.NonFatal
 
-import scala.meta.internal.fastpass.BuildInfo
 import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.internal.fastpass.pantsbuild.commands.Project
 import scala.meta.io.AbsolutePath
 
 import ujson.Obj
-import ujson.Str
 
 object VSCode {
   def launch(project: Project): Unit =
     try {
-      val settings = AbsolutePath(project.common.workspace)
-        .resolve(".vscode")
-        .resolve("settings.json")
-      val oldSettings = readSettings(settings)
-      oldSettings("metals.serverVersion") = BuildInfo.metalsVersion
-      oldSettings("metals.pantsTargets") = project.targets.map(Str(_))
-      oldSettings("metals.bloopVersion") = BuildInfo.bloopNightlyVersion
-      settings.writeText(ujson.write(oldSettings, indent = 2))
-      scribe.info(s"updated: $settings")
       val code = codeCommand()
       exec(code, "--install-extension", "scalameta.metals")
       exec(code, "--new-window", project.common.workspace.toString())
@@ -83,12 +72,5 @@ object VSCode {
           .take(1)
           .headOption
     } yield file
-  }
-  private def readSettings(settings: AbsolutePath): Obj = {
-    if (settings.isFile) {
-      ujson.read(settings.readText).obj
-    } else {
-      Obj()
-    }
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")


### PR DESCRIPTION
Previously, `fastpass create --vscode` wrote to `.vscode/settings.json`
requiring an old version of Metals. This was necessary before when users
needed a SNAPSHOT release of Metals in order use it with Pants. This is
no longer necessary so Fastpass now no longer writes to
`.vscode/settings.json`.