### PR TITLE
Keep dashes in projects' names

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsConfiguration.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsConfiguration.scala
@@ -112,7 +112,7 @@ object PantsConfiguration {
     buf.result().map(workspace.resolve)
   }
   def outputFilename(target: String): String = {
-    target.replace('/', '.').replaceAll("[^a-zA-Z0-9\\._]", "")
+    target.replace('/', '.').replaceAll("[^a-zA-Z0-9\\._-]", "")
   }
   def outputFilename(targets: List[String]): String = {
     val processed = targets


### PR DESCRIPTION
Previously, Fastpass would strip dashes from a project's name, which
hinders legibility of project names. This commit changes this, so that
dashes are not removed anymore.