### PR TITLE
Keep info about source root in sources.jar file

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -456,7 +456,6 @@ private class BloopPants(
     val result = new ConcurrentHashMap[Path, Path]
     resolutionTargets.stream().parallel().forEach { target =>
       target.targetBase.foreach { targetBase =>
-        val sourceRoot = AbsolutePath(workspace).resolve(targetBase)
         val sources = target.internalSourcesJar
         Files.deleteIfExists(sources)
         FileIO.withJarFileSystem(
@@ -464,7 +463,9 @@ private class BloopPants(
           create = true,
           close = true
         ) { root =>
+          val sourceRoot = AbsolutePath(workspace).resolve(targetBase)
           val jars = new SourcesJarBuilder(export, root.toNIO)
+          jars.writeSourceRoot(sourceRoot.toRelative(AbsolutePath(workspace)))
           getSources(target)
             .foreach(dir => jars.expandDirectory(AbsolutePath(dir), sourceRoot))
           getSourcesGlobs(target, target.baseDirectory).iterator.flatten

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/SourcesJarBuilder.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/SourcesJarBuilder.scala
@@ -22,6 +22,20 @@ import bloop.config.Config.SourcesGlobs
 
 /** Helper class to generate `*-sources.jar` files. */
 class SourcesJarBuilder(export: PantsExport, root: Path) {
+  def writeSourceRoot(sourceRoot: RelativePath): Unit =
+    try {
+      val out =
+        root.resolve("META-INF").resolve("fastpass").resolve("source-root")
+      Files.createDirectories(out.getParent)
+      Files.write(
+        out,
+        sourceRoot.toString().getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING
+      )
+    } catch {
+      case NonFatal(_) =>
+    }
 
   private def write(source: AbsolutePath, path: RelativePath): Unit = {
     val out = root.resolve(path.toString())

--- a/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
+++ b/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
@@ -1,5 +1,7 @@
 package tests
 
+import java.nio.charset.StandardCharsets
+
 import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
 
@@ -261,10 +263,29 @@ class BloopPantsSuite extends FastpassSuite {
     assertNoDiff(
       relativePaths.sorted.mkString("\n"),
       """
+        |META-INF/fastpass/source-root
         |lib/Hello1.scala
         |lib/Hello2.scala
         |""".stripMargin
     )
+
+    val sourceRootContents = {
+      FileIO.withJarFileSystem(
+        AbsolutePath(libSources),
+        create = false,
+        close = true
+      ) { root =>
+        val bytes = FileIO
+          .readAllBytes(root.resolve("META-INF/fastpass/source-root"))
+        new String(bytes, StandardCharsets.UTF_8)
+      }
+    }
+
+    assertNoDiff(
+      "lib/src/main/scala",
+      sourceRootContents
+    )
+
   }
 
   test("specify main_class") {


### PR DESCRIPTION
Necessary if we want to map sources.jar back to the local filesystem