### PR TITLE
Pass `runtime_platform` to Bloop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val V = new {
   val scala212 = "2.12.11"
-  val bloop = "1.4.4"
+  val bloop = "1.4.6"
   val coursierInterfaces = "0.0.22"
   val scribe = "2.7.12"
   val ujson = "1.1.0"

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -558,6 +558,7 @@ private class BloopPants(
     val out: Path = bloopDir.resolve(target.directoryName)
     val classesDir = target.classesDir
     val javaHome: Option[Path] = target.platform.map(Paths.get(_))
+    val runtimeJavaHome: Option[Path] = target.runtimePlatform.map(Paths.get(_))
 
     val resources: Option[List[Path]] =
       if (!target.targetType.isResourceOrTestResource) None
@@ -580,6 +581,9 @@ private class BloopPants(
     val extraJvmOptions =
       if (target.targetType.isTest) target.extraJvmOptions else Nil
 
+    val fullJvmOptions =
+      List(s"-Duser.dir=$workspace") ++ extraJvmOptions
+
     C.Project(
       name = target.dependencyName,
       directory = baseDirectory,
@@ -600,11 +604,15 @@ private class BloopPants(
         C.Platform.Jvm(
           C.JvmConfig(
             javaHome,
-            List(
-              s"-Duser.dir=$workspace"
-            ) ++ extraJvmOptions
+            fullJvmOptions
           ),
           target.mainClass,
+          runtimeJavaHome.map(_ =>
+            C.JvmConfig(
+              runtimeJavaHome,
+              fullJvmOptions
+            )
+          ),
           Some(runtimeClasspath),
           None
         )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExport.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExport.scala
@@ -71,6 +71,10 @@ object PantsExport {
         platform <- value.get(PantsKeys.platform)
         javaHome <- jvmPlatforms.get(platform.str)
       } yield javaHome
+      val runtimePlatform = for {
+        runtimePlatform <- value.get(PantsKeys.runtimePlatform)
+        javaHome <- jvmPlatforms.get(runtimePlatform.str)
+      } yield javaHome
       val libraries: mutable.ArrayBuffer[String] =
         value(PantsKeys.libraries).arr.map(_.str.intern())
       val compileLibraries: mutable.ArrayBuffer[String] = value
@@ -112,6 +116,7 @@ object PantsExport {
         javaSources = javaSources,
         excludes = excludes.asScala,
         platform = platform,
+        runtimePlatform = runtimePlatform,
         libraries = libraries,
         isPantsTargetRoot = isPantsTargetRoot,
         isPantsModulizable = isPantsModulizable,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsKeys.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsKeys.scala
@@ -21,6 +21,7 @@ object PantsKeys {
   val sourceRoot = "source_root"
   val preferredJvmDistributions = "preferred_jvm_distributions"
   val platform = "platform"
+  val runtimePlatform = "runtime_platform"
   val jvmPlatforms = "jvm_platforms"
   val defaultPlatform = "default_platform"
   val java8 = "java8"

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTarget.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsTarget.scala
@@ -10,6 +10,7 @@ class PantsTarget(
     val javaSources: collection.Seq[String],
     val excludes: collection.Set[String],
     val platform: Option[String],
+    val runtimePlatform: Option[String],
     val libraries: collection.Seq[String],
     val isPantsTargetRoot: Boolean,
     val isPantsModulizable: Boolean,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SharedCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SharedCommand.scala
@@ -170,7 +170,7 @@ object SharedCommand {
     val isOutdated = Set[String](
       "1.4.0-RC1-235-3231567a", "1.4.0-RC1-190-ef7d8dba",
       "1.4.0-RC1-167-61fbbe08", "1.4.0-RC1-69-693de22a",
-      "1.4.0-RC1+33-dfd03f53", "1.4.0-RC1", "1.4.1", "1.4.2", "1.4.3"
+      "1.4.0-RC1+33-dfd03f53", "1.4.0-RC1", "1.4.1", "1.4.2", "1.4.3", "1.4.4"
     )
     Try {
       val version = List("bloop", "--version").!!.linesIterator

--- a/tests/slow/src/test/scala/tests/BloopAssertions.scala
+++ b/tests/slow/src/test/scala/tests/BloopAssertions.scala
@@ -92,7 +92,7 @@ trait BloopAssertions extends munit.Assertions {
 
     private def onRuntimeClasspath(op: List[Path] => Unit): Unit = {
       project.platform match {
-        case Some(Platform.Jvm(_, _, Some(runtimeClasspath), _)) =>
+        case Some(Platform.Jvm(_, _, _, Some(runtimeClasspath), _)) =>
           op(runtimeClasspath)
         case _ =>
           op(project.classpath)


### PR DESCRIPTION
Previously, the `runtime_platform` of Pants targets would be ignored by
Fastpass. This commit uses it to create a new runtime JdkConfig that
will be used by Bloop at runtime.