### PR TITLE
Fastpass create: don't fail if project already exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: tests/slow/target/pants
-          key: ${{ runner.os }}-pants-repo-${{ hashFiles('project/PantsRepo.scala') }}
-          restore-keys: ${{ runner.os }}-pants-repo-${{ hashFiles('project/PantsRepo.scala') }}
+          key: ${{ runner.os }}-pants-repo-${{ hashFiles('project/PantsRepo.scala') }}-1
+          restore-keys: ${{ runner.os }}-pants-repo-${{ hashFiles('project/PantsRepo.scala') }}-1
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pants

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
@@ -4,8 +4,6 @@ import java.io.File
 
 import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.internal.fastpass.pantsbuild.Export
-import scala.meta.internal.fastpass.pantsbuild.IntelliJ
-import scala.meta.internal.fastpass.pantsbuild.VSCode
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 
@@ -47,18 +45,16 @@ object CreateCommand extends Command[CreateOptions]("create") {
     val name = create.actualName
     Project.fromName(name, create.common) match {
       case Some(value) =>
-        app.warn(
+        app.error(
           s"can't create project named '${name}' because it already exists." +
             s"\n\tTo refresh the project run: 'fastpass refresh ${name}'" +
             s"\n\tTo open the project run: 'fastpass open --intellij ${name}'" +
             s"\n\t                     or: 'fastpass open --vscode ${name}'"
         )
-        if (create.open.intellij) {
-          IntelliJ.launch(value, OpenOptions.default)
-        } else if (create.open.vscode) {
-          VSCode.launch(value)
-        }
-        0
+        if (create.open.launch(value))
+          0
+        else
+          1
 
       case None =>
         val project = Project.create(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/CreateCommand.scala
@@ -4,6 +4,8 @@ import java.io.File
 
 import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.internal.fastpass.pantsbuild.Export
+import scala.meta.internal.fastpass.pantsbuild.IntelliJ
+import scala.meta.internal.fastpass.pantsbuild.VSCode
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 
@@ -45,11 +47,19 @@ object CreateCommand extends Command[CreateOptions]("create") {
     val name = create.actualName
     Project.fromName(name, create.common) match {
       case Some(value) =>
-        app.error(
+        app.warn(
           s"can't create project named '${name}' because it already exists." +
-            s"\n\tTo refresh the project run: fastpass refresh ${name}"
+            s"\n\tTo refresh the project run: 'fastpass refresh ${name}'" +
+            s"\n\tTo open the project run: 'fastpass open --intellij ${name}'" +
+            s"\n\t                     or: 'fastpass open --vscode ${name}'"
         )
-        1
+        if (create.open.intellij) {
+          IntelliJ.launch(value, OpenOptions.default)
+        } else if (create.open.vscode) {
+          VSCode.launch(value)
+        }
+        0
+
       case None =>
         val project = Project.create(
           name,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/OpenCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/OpenCommand.scala
@@ -1,8 +1,5 @@
 package scala.meta.internal.fastpass.pantsbuild.commands
 
-import scala.meta.internal.fastpass.pantsbuild.IntelliJ
-import scala.meta.internal.fastpass.pantsbuild.VSCode
-
 import metaconfig.cli.CliApp
 import metaconfig.cli.Command
 import metaconfig.cli.Messages
@@ -51,12 +48,7 @@ object OpenCommand extends Command[OpenOptions]("open") {
         onEmpty(project, app)
         1
       } else {
-        if (open.intellij) {
-          IntelliJ.launch(project, open)
-        }
-        if (open.vscode) {
-          VSCode.launch(project)
-        }
+        open.launch(project)
         0
       }
     }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/OpenOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/OpenOptions.scala
@@ -2,6 +2,9 @@ package scala.meta.internal.fastpass.pantsbuild.commands
 
 import java.nio.file.Path
 
+import scala.meta.internal.fastpass.pantsbuild.IntelliJ
+import scala.meta.internal.fastpass.pantsbuild.VSCode
+
 import metaconfig.ConfDecoder
 import metaconfig.ConfEncoder
 import metaconfig.annotation._
@@ -28,9 +31,23 @@ case class OpenOptions(
 ) {
   def withProject(project: Project): OpenOptions =
     copy(projects = List(project.name))
+
   def withWorkspace(workspace: Path): OpenOptions =
     copy(common = common.copy(workspace = workspace))
+
   def isEmpty: Boolean = !intellij && !vscode
+
+  def launch(project: Project): Boolean = {
+    if (intellij) {
+      IntelliJ.launch(project, this)
+      true
+    } else if (vscode) {
+      VSCode.launch(project)
+      true
+    } else {
+      false
+    }
+  }
 }
 
 object OpenOptions {


### PR DESCRIPTION
Prevously, `fastpass create --intellij <target>` was failing if the BSP
workspace was already existing. Now it does not fail and opens IDE, in the
same way as it was doing previously for newly created BSP workspaces.