### PR TITLE
Allow changing coursier download URL with env var

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -161,12 +161,13 @@ object IntelliJ {
     } else if (Files.exists(destination)) {
       throw new IllegalArgumentException(s"file already exists: destination")
     } else {
-      val url = new URL("https://git.io/coursier-cli")
+      val url = sys.env
+        .getOrElse("FASTPASS_COURSIER_URL", "https://git.io/coursier-cli")
       Files.copy(
-        url.openConnection().getInputStream(),
+        new URL(url).openConnection().getInputStream(),
         destination
       )
-      destination.toFile().setExecutable(true)
+      destination.toFile.setExecutable(true)
       destination
     }
   }


### PR DESCRIPTION
The problem with current fastpass is that it downloads coursier from URL that is not available in every environment.
This env var will enable to easily change the download URL for coursier in a single place on CI for example (for all the ways fastpass can be started, for example from inside IDE), which would be more complicated with the existing flag for coursier path).