### PR TITLE
Look for `scala-library` in libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 lazy val V = new {
-  val scala212 = "2.12.11"
+  val scala212 = "2.12.13"
   val bloop = "1.4.8"
   val coursierInterfaces = "0.0.22"
   val scribe = "2.7.12"
   val ujson = "1.1.0"
   val metaconfig = "0.9.10"
-  val scalameta = "4.3.10"
+  val scalameta = "4.4.0"
   val bsp = "2.0.0-M4+10-61e61e87"
   val munit = "0.7.7"
 }
@@ -91,7 +91,7 @@ inThisBuild(
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     scalafixCaching := true,
-    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.3.1-RC3"
+    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"
   )
 )
 

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -264,18 +264,18 @@ private class BloopPants(
   def workspace: Path = args.workspace
   def userTargets: List[String] = args.targets
 
-  private val scalaCompiler = "org.scala-lang:scala-compiler:"
+  private val scalaLibrary = "org.scala-lang:scala-library:"
   private val transitiveClasspath = new ju.HashMap[String, List[Path]]().asScala
   private val isVisited = mutable.Set.empty[String]
 
-  val compilerVersion: String = export.libraries.keysIterator
+  val scalaVersion: String = export.libraries.keysIterator
     .collectFirst {
-      case module if module.startsWith(scalaCompiler) =>
-        module.stripPrefix(scalaCompiler)
+      case module if module.startsWith(scalaLibrary) =>
+        module.stripPrefix(scalaLibrary)
     }
     .getOrElse {
       scribe.warn(
-        s"missing scala-compiler: falling back to ${Properties.versionNumberString}"
+        s"missing scala-library: falling back to ${Properties.versionNumberString}"
       )
       Properties.versionNumberString
     }
@@ -766,7 +766,7 @@ private class BloopPants(
       C.Scala(
         "org.scala-lang",
         "scala-compiler",
-        compilerVersion,
+        scalaVersion,
         scalacOptions,
         allScalaJars,
         None,
@@ -814,10 +814,9 @@ private class BloopPants(
     )
 
   private def isScalaJar(module: String): Boolean =
-    module.startsWith(scalaCompiler) ||
+    module.startsWith(scalaLibrary) ||
       module.startsWith("org.scala-lang:scala-reflect:") ||
-      module.startsWith("org.scala-lang:scala-library:") ||
-      module.startsWith("org.scala-lang:scala-library:") ||
+      module.startsWith("org.scala-lang:scala-compiler:") ||
       module.startsWith("org.fursesource:jansi:") ||
       module.startsWith("jline:jline:")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.27")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")


### PR DESCRIPTION
Previously, we would attempt to detect the scala version used by a
target by looking for the Scala compiler in the libraries. It turns out,
however, that the Scala compiler is not always used as a library in a
target, and Fastpass would use the Scala version defined in this build
(Fastpass' build!) as Scala version of the created target.

This commit changes this logic so that we look for the Scala library
instead.

It also bumps the Scala version so that we have something more recent by
default.