### PR TITLE
Allow specifying coursier path in env variables

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -64,7 +64,7 @@ object IntelliJ {
   def writeBsp(
       project: Project,
       shared: SharedOptions,
-      coursierBinary: Option[Path] = None,
+      coursierBinary: Option[Path] = coursierFromEnv(),
       exportResult: Option[PantsExportResult] = None
   ): Unit = {
     SharedCommand.runScalafmtSymlink(project, shared)
@@ -191,4 +191,7 @@ object IntelliJ {
     }
     project.root.pantsLibrariesJson.writeText(ujson.write(libraries))
   }
+
+  private def coursierFromEnv(): Option[Path] =
+    sys.env.get("COURSIER_BINARY").map(Paths.get(_))
 }


### PR DESCRIPTION
Previously, the path to the coursier binary could be specified only on
the command line by passing `--coursier-binary` to `fastpass create`.
This solution, while working, offered a poor user experience on machines
that don't have access to the Internet, because users would need to
remember about this parameter.

This commit allows specifying the path to the coursier binary via
environment variable (`COURSIER_BINARY`). When this environment variable
is set, and it's value describes an existing file, then Fastpass will
not try to download coursier.