### PR TITLE
Update to Bloop 1.4.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val V = new {
   val scala212 = "2.12.13"
-  val bloop = "1.4.8"
-  val coursierInterfaces = "0.0.22"
+  val bloop = "1.4.13"
+  val coursierInterfaces = "1.0.6"
   val scribe = "2.7.12"
   val ujson = "1.1.0"
   val metaconfig = "0.9.10"
@@ -133,7 +133,6 @@ lazy val fastpass = project
       "com.lihaoyi" %% "ujson" % V.ujson,
       "ch.epfl.scala" %% "bloop-frontend" % V.bloop,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
-      "ch.epfl.scala" %% "bloop-launcher" % V.bloop,
       "org.scalameta" %% "trees" % V.scalameta,
       "ch.epfl.scala" % "bsp4j" % V.bsp
     ),
@@ -171,7 +170,7 @@ lazy val fastpass = project
       assert(reflectionFile.exists, "no such file: " + reflectionFile)
       List(
         "--initialize-at-build-time",
-        "--initialize-at-run-time=scala.meta.internal.fastpass,metaconfig",
+        "--initialize-at-run-time=scala.meta.internal.fastpass,metaconfig,scala.util.Random,coursierapi.internal.jniutils.ApiInternalNativeApi",
         "--no-server",
         "--enable-http",
         "--enable-https",

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/IntelliJ.scala
@@ -145,7 +145,7 @@ object IntelliJ {
     if (!configDir.exists) configDir.createDirectories
     val currentSettings = WorkspaceSettings
       .readFromFile(configDir, NoopLogger)
-      .getOrElse(WorkspaceSettings(None, None, None, None))
+      .getOrElse(WorkspaceSettings(None, None, None, None, None))
     val settings =
       currentSettings.copy(
         refreshProjectsCommand = Some(refreshCommand),

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SharedCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/commands/SharedCommand.scala
@@ -1,12 +1,10 @@
 package scala.meta.internal.fastpass.pantsbuild.commands
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Promise
 import scala.sys.process._
 import scala.util.Failure
 import scala.util.Success
@@ -23,8 +21,6 @@ import scala.meta.internal.fastpass.pantsbuild.IntelliJ
 import scala.meta.internal.fastpass.pantsbuild.MessageOnlyException
 import scala.meta.internal.fastpass.pantsbuild.PantsExportResult
 
-import bloop.bloopgun.core.Shell
-import bloop.launcher.LauncherMain
 import metaconfig.cli.CliApp
 import metaconfig.cli.TabCompletionContext
 import metaconfig.cli.TabCompletionItem
@@ -176,7 +172,7 @@ object SharedCommand {
       "1.4.0-RC1-235-3231567a", "1.4.0-RC1-190-ef7d8dba",
       "1.4.0-RC1-167-61fbbe08", "1.4.0-RC1-69-693de22a",
       "1.4.0-RC1+33-dfd03f53", "1.4.0-RC1", "1.4.1", "1.4.2", "1.4.3", "1.4.4",
-      "1.4.6"
+      "1.4.6", "1.4.8"
     )
     Try {
       val version = List("bloop", "about").!!.linesIterator
@@ -195,20 +191,11 @@ object SharedCommand {
 
   private def restartBloopServer(): Unit = {
     List("bloop", "exit").!
-    new LauncherMain(
-      clientIn = System.in,
-      clientOut = System.out,
-      out = System.out,
-      charset = StandardCharsets.UTF_8,
-      shell = Shell.default,
-      userNailgunHost = None,
-      userNailgunPort = None,
-      startedServer = Promise[Unit]()
-    ).runLauncher(
-      bloopVersionToInstall = BuildInfo.bloopVersion,
-      skipBspConnection = true,
-      serverJvmOptions = Nil
-    )
+    List(
+      "bloop",
+      "about",
+      s"--fallback-bloop-version=${BuildInfo.bloopVersion}"
+    ).!
   }
 
   private def defaultJavaHomePath: Option[Path] = {


### PR DESCRIPTION
This commit introduces some changes that are required for the native
image to build. It starts removing the binary dependency on Bloop by
shelling out to Bloop for restart.