### PR TITLE
Bump to newer version of junit-interface

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -287,7 +287,7 @@ private class BloopPants(
       // automatically registers org.scalatest.junit.JUnitRunner and
       // org.scalatestplus.junit.JUnitRunner even if there is no `@RunWith`
       // annotation.
-      Dependency.of("org.scalameta", "junit-interface", "0.7.11")
+      Dependency.of("org.scalameta", "junit-interface", "1.0.0-M3")
     ).flatMap(fetchDependency)
 
   private val mutableJarsHome = workspace.resolve(".pants.d")


### PR DESCRIPTION
This newer version was recently improved to support running a single
test case. This commit updates the version of the junit interface that
we inject in the Bloop projects that Fastpass creates.