### PR TITLE
Remote cache support for Fastpass export

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val V = new {
   val scalameta = "4.4.0"
   val bsp = "2.0.0-M4+10-61e61e87"
   val munit = "0.7.7"
+  val xz = "1.9"
 }
 
 val MUnitFramework = new TestFramework("munit.Framework")
@@ -134,7 +135,8 @@ lazy val fastpass = project
       "ch.epfl.scala" %% "bloop-frontend" % V.bloop,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
       "org.scalameta" %% "trees" % V.scalameta,
-      "ch.epfl.scala" % "bsp4j" % V.bsp
+      "ch.epfl.scala" % "bsp4j" % V.bsp,
+      "org.tukaani" % "xz" % V.xz
     ),
     buildInfoPackage := "scala.meta.internal.fastpass",
     buildInfoKeys := Seq[BuildInfoKey](

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/ActionGraph.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/ActionGraph.scala
@@ -68,31 +68,31 @@ class ActionGraph(
     }
   }
 
-  def toJson: Obj = {
+  def toJson(index: JsonUtils.ProtoIndex): Obj = {
     val newJson = Obj()
     newJson("labelToActions") = JsonUtils.mapToJson(labelToActions)(
       "label",
       Str(_),
       "actions",
-      _.map(JsonUtils.protoToJson)
+      _.map(JsonUtils.protoToJson(index, _))
     )
     newJson("idToDepSetOfFiles") = JsonUtils.mapToJson(idToDepSetOfFiles)(
       "id",
       _.toString,
       "depset",
-      JsonUtils.protoToJson
+      JsonUtils.protoToJson(index, _)
     )
     newJson("idToArtifact") = JsonUtils.mapToJson(idToArtifact)(
       "id",
       _.toString,
       "artifact",
-      JsonUtils.protoToJson
+      JsonUtils.protoToJson(index, _)
     )
     newJson("idToPathFragment") = JsonUtils.mapToJson(idToPathFragment)(
       "id",
       _.toString,
       "pathFragment",
-      JsonUtils.protoToJson
+      JsonUtils.protoToJson(index, _)
     )
     newJson
   }
@@ -113,34 +113,34 @@ object ActionGraph {
     )
   }
 
-  def fromJson(js: Value): ActionGraph = {
+  def fromJson(protoIndex: IndexedSeq[Value], js: Value): ActionGraph = {
     val labelToAction = JsonUtils.mapFromJson(
       js("labelToActions"),
       "label",
       _.str,
       "actions",
-      _.arr.toList.map(JsonUtils.jsonToProto(_)(Action.parseFrom))
+      _.arr.toList.map(JsonUtils.jsonToProto(protoIndex, _)(Action.parseFrom))
     )
     val idToDepSetOfFiles = JsonUtils.mapFromJson(
       js("idToDepSetOfFiles"),
       "id",
       _.str.toInt,
       "depset",
-      JsonUtils.jsonToProto(_)(DepSetOfFiles.parseFrom)
+      JsonUtils.jsonToProto(protoIndex, _)(DepSetOfFiles.parseFrom)
     )
     val idToArtifact = JsonUtils.mapFromJson(
       js("idToArtifact"),
       "id",
       _.str.toInt,
       "artifact",
-      JsonUtils.jsonToProto(_)(Artifact.parseFrom)
+      JsonUtils.jsonToProto(protoIndex, _)(Artifact.parseFrom)
     )
     val idToPathFragment = JsonUtils.mapFromJson(
       js("idToPathFragment"),
       "id",
       _.str.toInt,
       "pathFragment",
-      JsonUtils.jsonToProto(_)(PathFragment.parseFrom)
+      JsonUtils.jsonToProto(protoIndex, _)(PathFragment.parseFrom)
     )
     new ActionGraph(
       labelToAction,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -200,7 +200,7 @@ class Bazel(bazelPath: Path, cwd: Path) {
     // Extract source globs by groups of at most 100 packages to avoid
     // going over the command line max size.
     pkgs
-      .sliding(100)
+      .sliding(100, 100)
       .foldLeft(Map.empty[String, (List[String], List[String])]) {
         case (acc, pkgGroup) =>
           acc ++ groupedSourcesGlobs(pkgGroup)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/CacheCredentials.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/CacheCredentials.scala
@@ -1,0 +1,105 @@
+package scala.meta.internal.fastpass.bazelbuild
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Base64
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+final case class Credentials(
+    username: String,
+    password: String
+) {
+  def encoded: String = {
+    val bytes = s"$username:$password".getBytes("UTF-8")
+    "Basic " + new String(Base64.getEncoder.encode(bytes));
+  }
+}
+
+object CacheCredentials {
+
+  private case class Machine(
+      host: String,
+      username: String,
+      password: String
+  )
+
+  def read(
+      host: String,
+      js: ujson.Value
+  ): Option[Credentials] = {
+    js.arr.foldLeft(Option.empty[Credentials]) {
+      case (acc, entry) =>
+        acc.orElse(filterCred(host, entry))
+    }
+  }
+
+  private def filterCred(
+      host: String,
+      cred: ujson.Value
+  ): Option[Credentials] = {
+    for {
+      tpe <- cred.obj.get("type").map(_.str)
+      path <- cred.obj.get("path").map(p => Paths.get(p.str))
+      if Files.isReadable(path)
+      credentials <- getCredentials(host, tpe, path)
+    } yield credentials
+  }
+
+  private val yamlCredentials = """(.+?): (.+?)""".r
+  private def getCredentials(
+      host: String,
+      tpe: String,
+      path: Path
+  ): Option[Credentials] =
+    tpe match {
+      case "yaml" =>
+        Files.readAllLines(path).asScala.collectFirst {
+          case yamlCredentials(username, password) =>
+            Credentials(username, password)
+        }
+      case "netrc" =>
+        val machines = parseNetRc(
+          Nil,
+          Files
+            .readAllLines(path)
+            .asScala
+            .mkString(" ")
+            .split(" ")
+            .filterNot(_.isEmpty)
+            .toList
+        )
+        machines
+          .find(_.host == host)
+          .orElse(machines.find(_.host == "default"))
+          .map {
+            case Machine(_, username, password) =>
+              Credentials(username, password)
+          }
+
+      case _ =>
+        None
+    }
+
+  @scala.annotation.tailrec
+  private def parseNetRc(
+      acc: List[Machine],
+      tokens: List[String]
+  ): List[Machine] =
+    (acc, tokens) match {
+      case (_, "default" :: rest) =>
+        parseNetRc(Machine("default", "", "") :: acc, rest)
+      case (_, "machine" :: name :: rest) =>
+        parseNetRc(Machine(name, "", "") :: acc, rest)
+      case (curr :: machines, "login" :: login :: rest) =>
+        parseNetRc(curr.copy(username = login) :: machines, rest)
+      case (curr :: machines, "password" :: password :: rest) =>
+        parseNetRc(curr.copy(password = password) :: machines, rest)
+      case (_, _ :: rest) =>
+        parseNetRc(acc, rest)
+      case (_, Nil) =>
+        acc
+    }
+
+}

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/JsonUtils.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/JsonUtils.scala
@@ -1,0 +1,50 @@
+package scala.meta.internal.fastpass.bazelbuild
+
+import java.util.Base64
+
+import com.google.protobuf.MessageLite
+import ujson.Obj
+import ujson.Str
+import ujson.Value
+
+object JsonUtils {
+  def protoToJson(msg: MessageLite): Str = {
+    val str = new String(Base64.getEncoder.encode(msg.toByteArray()))
+    Str(str)
+  }
+
+  def mapToJson[K, V](obj: Map[K, V])(
+      keyKey: String,
+      keyOp: K => Value,
+      valueKey: String,
+      valueOp: V => Value
+  ): List[Obj] = {
+    obj.toList.map {
+      case (key, value) =>
+        val newJson = Obj()
+        newJson(keyKey) = keyOp(key)
+        newJson(valueKey) = valueOp(value)
+        newJson
+    }
+  }
+
+  def mapFromJson[K, V](
+      js: Value,
+      keyKey: String,
+      keyOp: Value => K,
+      valueKey: String,
+      valueOp: Value => V
+  ): Map[K, V] = {
+    js.arr.toList.map { entry =>
+      val key = keyOp(entry(keyKey))
+      val value = valueOp(entry(valueKey))
+      key -> value
+    }.toMap
+  }
+
+  def jsonToProto[T](js: Value)(op: Array[Byte] => T): T = {
+    val bytes = Base64.getDecoder().decode(js.str)
+    op(bytes)
+  }
+
+}

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/RemoteCache.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/RemoteCache.scala
@@ -1,0 +1,182 @@
+package scala.meta.internal.fastpass.bazelbuild
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import scala.meta.internal.fastpass.BuildInfo
+import scala.meta.internal.fastpass.MessageOnlyException
+import scala.meta.internal.fastpass.generic.Project
+
+sealed trait RemoteCache {
+  def getFromCache[T](filename: String)(op: InputStream => T): Try[T]
+  def writeToCache(filename: String)(op: OutputStream => Unit): Try[Boolean]
+}
+
+private class NoRemoteCache(reason: Throwable) extends RemoteCache {
+  override def getFromCache[T](filename: String)(op: InputStream => T): Try[T] =
+    Failure(reason)
+  override def writeToCache(
+      filename: String
+  )(op: OutputStream => Unit): Try[Boolean] =
+    Failure(reason)
+}
+
+private class HttpRemoteCache(
+    cacheConfig: CacheConfig,
+    cacheKey: String
+) extends RemoteCache {
+  def getFromCache[T](
+      filename: String
+  )(op: InputStream => T): Try[T] = {
+    val url = artifactUrl(filename)
+    Try {
+      val connection = url.openConnection()
+      val stream = new GZIPInputStream(connection.getInputStream())
+      try op(stream)
+      finally stream.close()
+    }
+  }
+
+  def writeToCache(filename: String)(op: OutputStream => Unit): Try[Boolean] = {
+    if (!cacheConfig.enableUpload) Success(false)
+    else {
+      val url = artifactUrl(filename)
+      Try {
+        url.openConnection() match {
+          case connection: HttpURLConnection =>
+            connection.setDoOutput(true)
+            connection.setRequestMethod("PUT")
+            cacheConfig.credentials.map(_.encoded).foreach {
+              connection.setRequestProperty("Authorization", _)
+            }
+            val stream = new GZIPOutputStream(connection.getOutputStream())
+            try {
+              op(stream)
+              stream.flush()
+            } finally {
+              stream.close()
+              connection.disconnect()
+            }
+
+            val responseCode = connection.getResponseCode()
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+              val responseMessage = connection.getResponseMessage()
+              throw new MessageOnlyException(
+                s"Write to cache failed: $responseCode $responseMessage"
+              )
+            } else {
+              true
+            }
+
+          case _ =>
+            throw new MessageOnlyException(
+              "Caching is only supported over HTTP(S)"
+            )
+        }
+      }
+    }
+  }
+
+  private def artifactUrl(filename: String): URL =
+    cacheConfig.uri
+      .resolve("buildcache/")
+      .resolve("1.0/")
+      .resolve(filename + ".gz/")
+      .resolve(cacheKey)
+      .toURL()
+}
+
+private case class CacheConfig(
+    uri: URI,
+    enableUpload: Boolean,
+    credentials: Option[Credentials]
+)
+
+object RemoteCache {
+  def configure(bazel: Bazel, project: Project): RemoteCache = {
+    val cache = for {
+      config <- readConfig(project.common.workspace)
+      key <- computeCacheKey(bazel, project)
+    } yield new HttpRemoteCache(config, key)
+
+    cache match {
+      case Failure(ex) => new NoRemoteCache(ex)
+      case Success(result) => result
+    }
+  }
+
+  private def readConfig(workspace: Path): Try[CacheConfig] = {
+    val configFile = workspace.resolve(".fastpass.json")
+    Try {
+      val js = ujson.read(configFile)
+      val url = URI.create(js("cache-url").str)
+      val credentials =
+        js.obj
+          .get("credentials")
+          .flatMap(CacheCredentials.read(url.getHost(), _))
+      val enableUpload =
+        js("enable-upload").boolOpt.getOrElse(credentials.isDefined)
+      CacheConfig(url, enableUpload, credentials)
+    }
+  }
+
+  private def computeCacheKey(bazel: Bazel, project: Project): Try[String] = {
+    val joinedTargets = project.targets.mkString(" + ")
+    bazel
+      .query(
+        "Computing project cache key",
+        s"""filter("^//", buildfiles($joinedTargets) + buildfiles(deps($joinedTargets)))"""
+      )
+      .map { result =>
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buildFiles = result
+          .getTargetList()
+          .asScala
+          .toList
+          .map { target =>
+            val location = target.getSourceFile().getLocation()
+            val colonIdx = location.indexOf(':')
+            if (colonIdx == -1) location
+            else location.substring(0, colonIdx)
+          }
+          .sorted
+          .distinct
+
+        digest.update(BuildInfo.fastpassVersion.getBytes("UTF-8"))
+        project.targets.foreach { target =>
+          digest.update(target.getBytes("UTF-8"))
+        }
+
+        buildFiles.foreach { buildFile =>
+          val path = Paths.get(buildFile)
+          if (Files.isReadable(path)) {
+            val bytes = Files.readAllBytes(path)
+            digest.update(bytes)
+          }
+        }
+
+        digest
+          .digest()
+          .map { h =>
+            val hex = Integer.toHexString(0xff & h)
+            if (hex.length == 1) hex + '0'
+            else hex
+          }
+          .mkString
+      }
+  }
+}

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/console/ProgressConsole.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/console/ProgressConsole.scala
@@ -55,7 +55,7 @@ object ProgressConsole {
       manual(title, elems.size) { advance =>
         elems.foreach { elem =>
           f(elem)
-          advance()
+          advance(1)
         }
       }
     }
@@ -74,16 +74,16 @@ object ProgressConsole {
       title: String,
       total: Long,
       output: Console = new ScrollableConsole(System.err, 5)
-  )(op: (() => Unit) => T): Try[T] = {
+  )(op: ((Long) => Unit) => T): Try[T] = {
     val console = new ProgressConsole(Progress.NoProgress, title, output)
     var currentProgress: Long = 0
-    val advance = () => {
+    val advance = (inc: Long) => {
       console.setProgress(
         ProgressUpdate.RemainingElements(currentProgress, total)
       )
-      currentProgress += 1
+      currentProgress += inc
     }
-    advance()
+    advance(0)
     timed(
       output.stream,
       title,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsGlobs.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsGlobs.scala
@@ -47,6 +47,12 @@ case class PantsGlobs(
       excludes = excludeGlobs
     )
   }
+  def toJson(): Value = {
+    val newJson = Obj()
+    newJson("globs") = include
+    newJson("exclude") = exclude.map(ex => Obj("globs" -> ex))
+    newJson
+  }
 }
 
 object PantsGlobs {


### PR DESCRIPTION
This commit introduces support for caching remotely the Bazel Fastpass
export. The export contains no machine-dependent machine, and can safely
be shared between machines.

Remote caching can be configured by creating a JSON file named
`.fastpass.json` in the workspace root. The JSON file supports the
following keys:
 - cache-url: A string, representing the URL of the remote cache server
 - credentials: An array of objects representing the locations where
   credentials for the remote cache server (if needed) can be found.
   Locations will be tried in order, and the first location that matches
   the remote cache host will be used.
   Each object of this array must contain the following keys:
    - type: A string, whose value must be either "yaml" or "netrc",
      defining the format of the credentials file.
    - path: A string, representing the path of the credentials file. If
      a file is not found or cannot be read, it is ignored.

    In YAML credential files, the first line that matches the following
    format will be considered to be valid credentials:
      `<username>: <password>`

    netrc credential files follow the netrc format.
 - enable-upload: This key is optional. Its value determines whether
   Fastpass runs will try to upload the export to the configured cache.
   If not specified, it'll default to false, unless credentials have
   been found for the remote cache host.

Configuration example:
```
{
        "cache-url": "http://localhost:8888/",
        "credentials": [
                {
                        "type": "yaml",
                        "path": "/etc/config/cache.yml"
                },
                {
                        "type": "netrc",
                        "path": "/home/jdoe/.netrc"
                }
        ],
        "enable-upload": true
}
```