### PR TITLE
Add `--stop-after-cache` option

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -31,6 +31,7 @@ object BloopBazel {
       workspace: Path,
       bazelBinary: Path,
       intellij: Boolean,
+      stopAfterCache: Boolean,
       app: CliApp
   ): Try[Option[PantsExportResult]] = {
     if (intellij) Success(None)
@@ -48,7 +49,10 @@ object BloopBazel {
           scalaJars,
           testFrameworksJars
         )
-      } yield bloopBazel.run()
+      } yield {
+        if (stopAfterCache) Success(None)
+        else bloopBazel.run()
+      }
     }.flatten
   }
 

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
@@ -55,6 +55,8 @@ object CreateCommand extends Command[CreateOptions]("create") {
           app.info(s"Project '$name' already exists; refreshing.")
           val refreshOptions = RefreshOptions(
             projects = name :: Nil,
+            stopAfterCache = create.stopAfterCache,
+            export = create.export,
             open = create.open,
             common = create.common
           )
@@ -96,6 +98,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
                 create.common.workspace,
                 create.common.bazelBinary,
                 create.open.intellij,
+                create.stopAfterCache,
                 app
               )
           }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateOptions.scala
@@ -24,6 +24,10 @@ case class CreateOptions(
       "Whether to use Bazel for project import. Defaults to false."
     )
     bazel: Boolean = false,
+    @Description(
+      "Whether to exit after updating the remote cache. Defaults to false."
+    )
+    stopAfterCache: Boolean = false,
     @Hidden() @Inline export: ExportOptions = ExportOptions.default,
     @Hidden() @Inline open: OpenOptions = OpenOptions.default,
     @Hidden() @Inline common: SharedOptions = SharedOptions.default

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshCommand.scala
@@ -51,6 +51,7 @@ object RefreshCommand extends Command[RefreshOptions]("refresh") {
             refresh.common.workspace,
             refresh.common.bazelBinary,
             refresh.open.intellij,
+            refresh.stopAfterCache,
             app
           )
           SharedCommand.postExportActions(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshOptions.scala
@@ -11,6 +11,10 @@ case class RefreshOptions(
     projects: List[String] = Nil,
     @Hidden()
     update: Boolean = false,
+    @Description(
+      "Whether to exit after updating the remote cache. Defaults to false."
+    )
+    stopAfterCache: Boolean = false,
     @Inline export: ExportOptions = ExportOptions.default,
     @Inline open: OpenOptions = OpenOptions.default,
     @Inline common: SharedOptions = SharedOptions()

--- a/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
+++ b/tests/slow/src/test/scala/tests/BloopPantsSuite.scala
@@ -605,8 +605,11 @@ class BloopPantsSuite extends FastpassSuite {
     val projects = workspace.projects()
     assertEquals(projects.keys, Set("-project-root", "core:core"))
 
+    // We need to prevent Bloop from restarting because it's not installed in CI.
     workspace
-      .run("create" :: "--name" :: "example/pants-project" :: "::" :: Nil)
+      .run(
+        "create" :: "--name" :: "example/pants-project" :: "::" :: "--no-bloop-exit" :: Nil
+      )
       .succeeds
   }
 


### PR DESCRIPTION
This option is used to stop creating the Fastpass project after the
remote cache has been updated. This allows to save some time in cases
where we're just interested in updating the remote cache.