### PR TITLE
Fix reading globs from cache

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -146,7 +146,7 @@ object BloopBazel {
         "target",
         JsonUtils.jsonToProto(protoIndex, _)(Target.parseFrom),
         "globs",
-        PantsGlobs.fromJson
+        js => PantsGlobs.fromJson(ujson.Obj("globs" -> js))
       )
     val rawTargetInputs =
       JsonUtils.mapFromJson(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsGlobs.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsGlobs.scala
@@ -50,7 +50,7 @@ case class PantsGlobs(
   def toJson(): Value = {
     val newJson = Obj()
     newJson("globs") = include
-    newJson("exclude") = exclude.map(ex => Obj("globs" -> ex))
+    newJson("exclude") = exclude.map(ex => Obj("globs" -> List(ex)))
     newJson
   }
 }


### PR DESCRIPTION
Previously, Fastpass would incorrectly read and write source globs from
cached targets, leading to targets with empty globs.