### PR TITLE
Actually make the `enable-upload` key optional

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/RemoteCache.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/RemoteCache.scala
@@ -136,7 +136,10 @@ object RemoteCache {
           .get("credentials")
           .flatMap(CacheCredentials.read(url.getHost(), _))
       val enableUpload =
-        js("enable-upload").boolOpt.getOrElse(credentials.isDefined)
+        js.obj
+          .get("enable-upload")
+          .flatMap(_.boolOpt)
+          .getOrElse(credentials.isDefined)
       CacheConfig(url, enableUpload, credentials)
     }
   }


### PR DESCRIPTION
Previously, Fastpass would fail to read the cache configuration if the
`enable-upload` key was not set in the configuration JSON.

The intended behavior, and the behavior with this patch, is to make this
key optional. It defaults to false unless there are credentials
available for the configured cache host.