### PR TITLE
Manage Python targets in Fastpass

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -156,6 +156,19 @@ class Bazel(bazelPath: Path, cwd: Path) {
     }
   }
 
+  def buildVEnv(location: Path, specs: List[String]): Try[Unit] = {
+    ProgressConsole.auto("Building Python virtual environment") { err =>
+      val cmd =
+        bazel :: "build-venv" :: "--location" :: location.toAbsolutePath.toString :: specs
+      val code = run(cmd, err, err)
+      if (code != 0) {
+        throw new MessageOnlyException(
+          "Could not build Python virtual environment."
+        )
+      }
+    }
+  }
+
   private def importDependencies(
       specs: List[String],
       supportedRules: List[String],
@@ -242,7 +255,7 @@ class Bazel(bazelPath: Path, cwd: Path) {
     }
   }
 
-  def run(
+  private def run(
       cmd: List[String],
       out: OutputStream,
       err: OutputStream = FileUtils.NullOutputStream

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/ProjectRoot.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/ProjectRoot.scala
@@ -9,4 +9,5 @@ case class ProjectRoot(
   val pantsLibrariesJson: AbsolutePath =
     bspRoot.resolve(".pants").resolve("libraries.json")
   val bloopRoot: AbsolutePath = bspRoot.resolve(".bloop")
+  val venvRoot: AbsolutePath = bspRoot.resolve(".venv")
 }

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/SharedCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/SharedCommand.scala
@@ -50,13 +50,25 @@ object SharedCommand {
           exportResult
         )
         exportResult.foreach { result =>
-          val targets =
+          val jvmTargets =
             LogMessages.pluralName(
-              s"${importMode} target",
-              result.exportedTargets
+              s"${importMode} JVM target",
+              result.exportedJvmTargets
             )
+          val pythonTargets =
+            LogMessages.pluralName(
+              "Python target",
+              result.exportedPythonTargets
+            )
+          val targets =
+            (result.exportedJvmTargets, result.exportedPythonTargets) match {
+              case (0, 0) => "no targets"
+              case (_, 0) => jvmTargets
+              case (0, _) => pythonTargets
+              case _ => s"$jvmTargets and $pythonTargets"
+            }
           app.info(
-            s"exported ${targets} to project '${project.name}' in $timer"
+            s"exported $targets to project '${project.name}' in $timer"
           )
         }
         SwitchCommand.runSymlinkOrWarn(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/SharedOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/SharedOptions.scala
@@ -28,6 +28,7 @@ case class SharedOptions(
     bazelPath: Option[Path] = None
 ) {
   def bloopDirectory: Path = workspace.resolve(".bloop")
+  def venvDirectory: Path = workspace.resolve(".venv")
   def pantsBinary: Path = pants.getOrElse(workspace.resolve("pants"))
   def bazelBinary: Path = bazelPath.getOrElse(workspace.resolve("bazel"))
   val home: AbsolutePath = AbsolutePath {

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -289,6 +289,7 @@ private class BloopPants(
     token.checkCanceled()
     new PantsExportResult(
       generatedProjects.size,
+      0,
       internalSources,
       export.jvmDistribution.javaHome,
       export.libraries.valuesIterator

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExportResult.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/PantsExportResult.scala
@@ -3,7 +3,8 @@ package scala.meta.internal.fastpass.pantsbuild
 import java.nio.file.Path
 
 class PantsExportResult(
-    val exportedTargets: Int,
+    val exportedJvmTargets: Int,
+    val exportedPythonTargets: Int,
     val internalSources: collection.Map[Path, Path],
     val javaHome: Option[Path],
     val libraries: Iterator[PantsLibrary]


### PR DESCRIPTION
This commit introduces support for Python targets within Fastpass with
Bazel. Fastpass delegates the creation of the Python virtual environment
to `bazel build-venv`, and takes care of managing the `.venv` symlink.