### PR TITLE
Include `scala_binary` targets

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -362,7 +362,8 @@ object BloopBazel {
     "scala_library" -> Set("Scalac"),
     "_java_library" -> Set("Scalac"),
     "_scala_macro_library" -> Set("Scalac"),
-    "scala_junit_test" -> Set("Scalac")
+    "scala_junit_test" -> Set("Scalac"),
+    "scala_binary" -> Set("Middleman")
   )
 
   private val forbiddenGenerators: List[String] = List(


### PR DESCRIPTION
Previously, Fastpass for Bazel would ignore the `scala_binary` targets.
It turns out, however, that there's use for these targets in Bloop since
they are runnable.

This commit re-enables them.