### PR TITLE
Generate synthetic project root

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/console/ProgressConsole.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/console/ProgressConsole.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.fastpass.console
 import java.io.PrintStream
 
 import scala.collection.GenTraversableLike
-import scala.collection.GenTraversableOnce
 import scala.collection.generic.CanBuildFrom
 import scala.util.Failure
 import scala.util.Try
@@ -31,19 +30,16 @@ class ProgressConsole(progress: Progress, title: String, output: Console)
 
 object ProgressConsole {
 
-  def flatMap[Repr[T] <: GenTraversableLike[T, Repr[T]], T, B, That](
+  def map[Repr[T] <: GenTraversableLike[T, Repr[T]], T, B, That](
       title: String,
       elems: Repr[T]
   )(
-      f: T => GenTraversableOnce[B]
+      f: T => B
   )(implicit bf: CanBuildFrom[Repr[T], B, That]): Try[That] = {
-    if (!elems.hasDefiniteSize) auto(title)(_ => elems.flatMap(f))
-    else {
-      val builder = bf()
-      foreach(title, elems) { elem =>
-        f(elem).foreach(builder += _)
-      }.map(_ => builder.result())
-    }
+    val builder = bf()
+    foreach(title, elems) { elem =>
+      builder += f(elem)
+    }.map(_ => builder.result())
   }
 
   def foreach[Repr[T] <: GenTraversableLike[T, Repr[T]], T](


### PR DESCRIPTION
Previously, Fastpass with Bazel would not generate synthetic project
roots that would group together projects that share the same root
directory, unlike Fastpass with Pants. This would lead to Fastpass
projects that are hard to navigate in IntelliJ.

This commit ports the logic from Fastpass for Pants to Fastpass for
Bazel.