### PR TITLE
Avoid source jars collisions

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -194,7 +194,8 @@ object BloopBazel {
         path.getFileName().toString().stripSuffix(strip) + add
       )
     }
-    val external = bazelInfo.bazelBin.resolve("external").toNIO
+    val bazelBin = bazelInfo.bazelBin.toNIO
+    val external = bazelBin.resolve("external")
     val sourceJars = mutable.Buffer.empty[Path]
     val inputMapping = mutable.Map.empty[Artifact, Path]
     // Ignore artifacts whose path end with these suffixes:
@@ -230,7 +231,8 @@ object BloopBazel {
             )
             possibleSourceJarsPaths.filter(Files.exists(_)).foreach {
               sourceJar =>
-                val mappedPath = dest.resolve(sourceJar.getFileName.toString)
+                val jarPath = bazelBin.relativize(sourceJar)
+                val mappedPath = dest.resolve(jarPath)
                 Files.createDirectories(mappedPath.getParent())
                 Files.copy(
                   sourceJar,


### PR DESCRIPTION
Previously, all the source jars would be copied in the same directory.
This means that if several source jars had the same filename, they would
override each other. This commit fixes the issue by keeping the package
structure, so that source jars no longer override each other.