### PR TITLE
Improve source roots detection

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -23,6 +23,11 @@ import scala.meta.internal.fastpass.console.ProgressConsole
 
 import com.google.protobuf.TextFormat
 
+object Bazel {
+  def isPlainSpec(spec: String): Boolean =
+    !spec.contains("(") && !spec.contains(" ")
+}
+
 class Bazel(bazelPath: Path, cwd: Path) {
   private val bazel: String = {
     val path = cwd.relativize(bazelPath)

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import scala.meta.internal.fastpass.FastpassEnrichments._
 import scala.meta.internal.fastpass.Time
 import scala.meta.internal.fastpass.Timer
+import scala.meta.internal.fastpass.bazelbuild.Bazel
 import scala.meta.internal.fastpass.bazelbuild.BloopBazel
 import scala.meta.internal.fastpass.pantsbuild.Export
 import scala.meta.internal.fastpass.pantsbuild.commands.SharedPantsCommand
@@ -130,7 +131,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
     if (isBazel) {
       val targets = create.targets.map { target =>
         // Don't touch targets that look like Bazel queries
-        if (target.contains(" ") || target.contains("(")) {
+        if (!Bazel.isPlainSpec(target)) {
           target
         }
         // Translate foo/bar to foo/bar/... This is inconsistent with Pants (foo/bar:bar),


### PR DESCRIPTION
Previously, Fastpass may not create a source root project for some
directories that had a target with empty globs at their root, which
would lead to a less than ideal experience in IntelliJ.