### PR TITLE
Version cache format

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -27,6 +27,9 @@ import bloop.config.Tag
 import metaconfig.cli.CliApp
 
 object BloopBazel {
+
+  final val CacheFormatVersion = "1"
+
   def run(
       project: Project,
       workspace: Path,
@@ -65,7 +68,7 @@ object BloopBazel {
       scalaJars: List[Path],
       testFrameworksJars: List[Path]
   ): Try[BloopBazel] = {
-    val cache = RemoteCache.configure(bazel, project)
+    val cache = RemoteCache.configure(bazel, project, CacheFormatVersion)
 
     cache
       .getFromCache(cachedExportName) { export =>


### PR DESCRIPTION
Previously, Fastpass would version the cache format with the Fastpass
version. This means that the cache would be invalidated whenever
there's a new release of Fastpass.

Since we don't expect the cache format to change often, and we have
entirely control over when it changes, it's better to explicitly version
the cache format.