### PR TITLE
Add `--ignore-cache` flag to ignore cache

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/RemoteCache.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/RemoteCache.scala
@@ -27,7 +27,7 @@ sealed trait RemoteCache {
   def writeToCache(filename: String)(op: OutputStream => Unit): Try[Boolean]
 }
 
-private class NoRemoteCache(reason: Throwable) extends RemoteCache {
+class NoRemoteCache(reason: Throwable) extends RemoteCache {
   override def getFromCache[T](filename: String)(op: InputStream => T): Try[T] =
     Failure(reason)
   override def writeToCache(

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
@@ -60,6 +60,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
           app.info(s"Project '$name' already exists; refreshing.")
           val refreshOptions = RefreshOptions(
             projects = name :: Nil,
+            ignoreCache = create.ignoreCache,
             stopAfterCache = create.stopAfterCache,
             export = create.export,
             open = create.open,
@@ -103,6 +104,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
                 create.common.workspace,
                 create.common.bazelBinary,
                 create.open.intellij,
+                create.ignoreCache,
                 create.stopAfterCache,
                 app
               )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateOptions.scala
@@ -25,6 +25,10 @@ case class CreateOptions(
     )
     bazel: Boolean = false,
     @Description(
+      "Whether to ignore the remote export cache. Defaults to false."
+    )
+    ignoreCache: Boolean = false,
+    @Description(
       "Whether to exit after updating the remote cache. Defaults to false."
     )
     stopAfterCache: Boolean = false,

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshCommand.scala
@@ -51,6 +51,7 @@ object RefreshCommand extends Command[RefreshOptions]("refresh") {
             refresh.common.workspace,
             refresh.common.bazelBinary,
             refresh.open.intellij,
+            refresh.ignoreCache,
             refresh.stopAfterCache,
             app
           )

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshOptions.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/RefreshOptions.scala
@@ -12,6 +12,10 @@ case class RefreshOptions(
     @Hidden()
     update: Boolean = false,
     @Description(
+      "Whether to ignore the remote export cache. Defaults to false."
+    )
+    ignoreCache: Boolean = false,
+    @Description(
       "Whether to exit after updating the remote cache. Defaults to false."
     )
     stopAfterCache: Boolean = false,


### PR DESCRIPTION
This cache allows creating or refreshing a project without looking up
the remote cache.