### PR TITLE
Approximate source root for target

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/pantsbuild/BloopPants.scala
@@ -11,7 +11,6 @@ import java.nio.file.StandardCopyOption
 import java.util.concurrent.ConcurrentHashMap
 import java.{util => ju}
 
-import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.sys.process.Process
@@ -167,28 +166,6 @@ object BloopPants {
       }
     }
   }
-
-  private val sourceRootPattern = FileSystems.getDefault.getPathMatcher(
-    "glob:**/{main,test,tests,src,3rdparty,3rd_party,thirdparty,third_party}/{resources,scala,java,jvm,proto,python,protobuf,py}"
-  )
-  private val defaultTestRootPattern = FileSystems.getDefault.getPathMatcher(
-    "glob:**/{test,tests}"
-  )
-
-  private def approximateSourceRoot(dir: Path): Option[Path] = {
-    @tailrec def loop(d: Path): Option[Path] = {
-      if (sourceRootPattern.matches(d)) Some(d)
-      else if (defaultTestRootPattern.matches(d)) Some(d)
-      else {
-        Option(d.getParent) match {
-          case Some(parent) => loop(parent)
-          case None => None
-        }
-      }
-    }
-    loop(dir)
-  }
-
 }
 
 private class BloopPants(


### PR DESCRIPTION
Previously, Fastpass would always use the target base directory as
source root. Some targets, however, have a parent directory as the
source root. This commit ports the logic that detects the source root
from Fastpass for Pants to Fastpass for Bazel.

This should fix issues where IntelliJ reports that the package name
doesn't correspond to the directory structure.