### PR TITLE
Added filter rules for targets to build

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -221,13 +221,21 @@ class Bazel(bazelPath: Path, cwd: Path) {
   }
 
   private def getTargets(result: QueryResult): List[Target] = {
+    val extToExclude = List(
+      ".semanticdb",
+      ".deployjar",
+      ".dirbundle",
+      ".dataconfig",
+      ".dataconfigjar"
+    )
+
     result
       .getTargetList()
       .asScala
       .toList
-      .filterNot(_.getRule().getName().endsWith(".semanticdb"))
-      .filterNot(_.getRule().getName().endsWith(".deployjar"))
-      .filterNot(_.getRule().getName().endsWith(".dirbundle"))
+      .filterNot(p =>
+        extToExclude.exists(e => p.getRule().getName().endsWith(e))
+      )
       .filterNot(_.getRule().getRuleClass().equals("alias"))
   }
 

--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -226,6 +226,9 @@ class Bazel(bazelPath: Path, cwd: Path) {
       .asScala
       .toList
       .filterNot(_.getRule().getName().endsWith(".semanticdb"))
+      .filterNot(_.getRule().getName().endsWith(".deployjar"))
+      .filterNot(_.getRule().getName().endsWith(".dirbundle"))
+      .filterNot(_.getRule().getRuleClass().equals("alias"))
   }
 
   def sourcesGlobs(


### PR DESCRIPTION
Added filter rules for targets to build to ensure Fastpass can import projects even if they don't build. This means after the changes: the dependencies must build in order to import project but source code does not have to build for this to happen.