### PR TITLE
Fix go to definition on Thrift symbols in IntelliJ

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -257,7 +257,11 @@ object BloopBazel {
             possibleSourceJarsPaths.filter(Files.exists(_)).foreach {
               sourceJar =>
                 val jarPath = execRoot.relativize(sourceJar)
-                val mappedPath = dest.resolve(jarPath)
+                // IntelliJ will not consider `.srcjar`s as source jars. We change the suffix to `-sources.jar`.
+                val mappedPath =
+                  if (jarPath.getFileName.toString.endsWith(".srcjar"))
+                    withSuffix(dest.resolve(jarPath), ".srcjar", "-sources.jar")
+                  else dest.resolve(jarPath)
                 Files.createDirectories(mappedPath.getParent())
                 Files.copy(
                   sourceJar,


### PR DESCRIPTION
Previously, running `go to definition` on Thrift symbols in IntelliJ
would take the user to decompiled class files, because the source jars
was not associated with the binary library. The source jars was no
associated because it would be named `<lib name>.srcjar`, which IntelliJ
would not recognize as a source jar. To fix the issue, we rename
`<lib name>.srcjar` to `<lib name>-sources.jar`, which IntelliJ will
correctly associate with `<lib name>.jar`.