### PR TITLE
Format the libraries.json file

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/IntelliJ.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/IntelliJ.scala
@@ -186,6 +186,6 @@ object IntelliJ {
       case (default, sources) =>
         libraries(default.toString()) = Str(sources.toString())
     }
-    project.root.pantsLibrariesJson.writeText(ujson.write(libraries))
+    project.root.pantsLibrariesJson.writeText(ujson.write(libraries, indent = 4))
   }
 }


### PR DESCRIPTION
Currently the JSON is printed as a single long line, which causes rendering problems when the file is opened in IntelliJ.