### PR TITLE
Avoid pulling in unnecessary java bootclasspath

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -411,9 +411,9 @@ object BloopBazel {
 
   private val supportedRules: Map[String, Set[String]] = Map(
     "scala_library" -> Set("Scalac"),
-    "_java_library" -> Set("Scalac", "Javac"),
+    "_java_library" -> Set("Scalac"),
     "_scala_macro_library" -> Set("Scalac"),
-    "scala_junit_test" -> Set("Scalac", "Javac"),
+    "scala_junit_test" -> Set("Scalac"),
     "scala_binary" -> Set("Middleman"),
     "_jvm_app" -> Set()
   )


### PR DESCRIPTION
Previously, Fastpass would build the classpath of Java targets using the
inputs of both the `Javac` and `Scalac` actions. In addition to the jars
appearing in the `Scalac` action, the `Javac` action has a jar named
`platformclasspath.jar` which will be put on the bootclasspath of Javac.
This additional jar would end up on the compilation classpath of the
targets, causing issues down the line (eg. wrong go to definition in
IntelliJ).

Because our Java targets are implemented using `scala_library`, we can
rely on the `Scalac` action alone: it contains all the necessary jars.
The inputs of `Javac` were added by mistake when working on a different
issue, and should never have been added in the first place.