### PR TITLE
Support `java_sources` in `scala_library` targets

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/SourcesInfo.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/SourcesInfo.scala
@@ -1,0 +1,31 @@
+package scala.meta.internal.fastpass.bazelbuild
+import ujson.Obj
+import ujson.Value
+
+final case class SourcesInfo(
+    include: List[String],
+    exclude: List[String],
+    javaSources: List[String]
+) {
+  def toJson: Value = {
+    val newJson = Obj()
+    newJson("include") = include
+    newJson("exclude") = exclude
+    newJson("javaSources") = javaSources
+    newJson
+  }
+}
+
+object SourcesInfo {
+
+  def fromJson(value: Value): SourcesInfo = {
+    SourcesInfo(
+      getStringList(value, "include"),
+      getStringList(value, "exclude"),
+      getStringList(value, "javaSources")
+    )
+  }
+
+  private def getStringList(value: Value, key: String): List[String] =
+    value.obj.get(key).map(_.arr.map(_.str).toList).getOrElse(Nil)
+}


### PR DESCRIPTION
 Previously, Fastpass would ignore the `java_sources` field that appears
in some `scala_library` targets. This field is used to denote that a circular
dependency between this target and the label(s) set in `java_sources`
exists. In order to compile a target that has `java_sources` set, the
sources of the labels that are set must be passed to the compiler along
with the sources of the target.