### PR TITLE
Don't import in IDE targets tagged with `no-ide` (and possibly `manual`)

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -106,12 +106,14 @@ object BloopBazel {
             dependencies <- bazel.dependenciesToBuild(
               project.targets,
               importableRules,
-              forbiddenGenerators
+              forbiddenGenerators,
+              forbiddenTags
             )
             importedTargets <- bazel.targetsInfos(
               project.targets,
               importableRules,
-              forbiddenGenerators
+              forbiddenGenerators,
+              forbiddenTags
             )
             actions <- bazel.aquery(importedTargets.map(_.getRule.getName))
             actionGraph = ActionGraph(actions)
@@ -425,6 +427,11 @@ object BloopBazel {
   private val forbiddenGenerators: Map[String, List[String]] = Map(
     "" -> List("create_datasets", "antlr"),
     "scala_library" -> List("jvm_app")
+  )
+
+  private val forbiddenTags: List[String] = List(
+    "no-ide",
+    "manual"
   )
 
   private val cachedExportName: String = "fastpass-export.json"


### PR DESCRIPTION
Added forbiddenTags to bazel query to exclude targets with tags that are not meant to be imported. Added tags: "no-ide" and "manual"