### PR TITLE
Fix default globs for `junit_tests` targets

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -1121,7 +1121,8 @@ private class BloopBazel(
     generatorFunction(target) match {
       case Some("scala_library") => PantsGlobs("*.scala" :: Nil, Nil)
       case Some("java_library") => PantsGlobs("*.java" :: Nil, Nil)
-      case Some("junit_tests") => PantsGlobs("*.scala" :: "*.java" :: Nil, Nil)
+      case Some("junit_tests") =>
+        PantsGlobs("*Test.scala" :: "*Spec.scala" :: "*Test.java" :: Nil, Nil)
       case _ => PantsGlobs.empty
     }
   }


### PR DESCRIPTION
Previously, Fastpass would include all Java and Scala sources living
under a `junit_tests` target. In our build, however, only the Java
sources suffixed with `Test` or Scala sources suffixed with `Test` or
`Spec` are considered as sources.