### PR TITLE
Collect inputs of Javac mnemonic

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -50,6 +50,9 @@ object Bazel {
     "@io_bazel_rules_scala//src/scala/scripts:scrooge_worker"
   val ScroogeWorkerMnemonic = "TemplateExpand"
 
+  val PlatformClasspathLabel =
+    "@bazel_tools//tools/jdk:platformclasspath"
+
   private val extToExclude = List(
     ".semanticdb",
     ".deployjar",


### PR DESCRIPTION
Previously, Fastpass would not collect the inputs of the `Javac` mnemonic for Java targets, and would focus only on the `Scalac` mnemonic. Unfortunately, it turns out that we cannot do this, because it appears that `strict_deps` is not applied to Java compilation with Bazel: their classpath will still contain all the transitive dependencies.

In order to avoid breaking go to definition on JDK classes in the IDE, we exclude the `platformclasspath` JAR from the classpath (Bloop will provide the right one from the environment).