### PR TITLE
Use pants only if pants is explicitly requested

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/generic/CreateCommand.scala
@@ -127,11 +127,7 @@ object CreateCommand extends Command[CreateOptions]("create") {
         create.common.workspace.resolve(target.stripPrefix("//"))
       )
 
-    // If we find a recursive glob of targets, then we know it's a pants import
-    val isPants =
-      create.forcePants || create.targets.exists(tgt => tgt.endsWith("::"))
-
-    if (isPants) {
+    if (create.forcePants) {
       val targets = create.targets.map { target =>
         // Translate foo/bar/... to foo/bar::
         if (target.endsWith("/...") && isDir(target.stripSuffix("/..."))) {


### PR DESCRIPTION
Previously, Fastpass would call Pants if it detected recursive globs (`foo/bar::`), even when Bazel was requested. Now, Fastpass will call Pants if and only if `--force-pants` is passed on the command line.