### PR TITLE
Substitute protobuf java ijar for full jar

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/Bazel.scala
@@ -53,6 +53,11 @@ object Bazel {
   val PlatformClasspathLabel =
     "@bazel_tools//tools/jdk:platformclasspath"
 
+  val ProtobufJava =
+    "@com_google_protobuf_protobuf_java//:com_google_protobuf_protobuf_java"
+  val ProtobufJavaMnemonic =
+    "JavaIjar"
+
   private val extToExclude = List(
     ".semanticdb",
     ".deployjar",


### PR DESCRIPTION
Previously, Fastpass would let the protobuf java ijar on the compilation classpath. Unfortunately, this can cause compilation issues, because Zinc will try to load the classes in the ijar and will crash.

As a workaround, we substitute the ijar for the full jar.