### PR TITLE
Temporarily disable Thrift support

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -482,10 +482,11 @@ object BloopBazel {
     "_scala_macro_library" -> Set("Scalac"),
     "scala_junit_test" -> Set("Scalac", "Javac"),
     "scala_binary" -> Set("Middleman"),
-    "_jvm_app" -> Set(),
-    "scrooge_scala_library" -> Set("ScroogeRule", "Scalac"),
-    "scrooge_java_library" -> Set("ScroogeRule", "Javac"),
-    "thrift_library" -> Set("ScroogeRule")
+    "_jvm_app" -> Set()
+    // Uncomment once Thrift support is ready.
+    // "scrooge_scala_library" -> Set("ScroogeRule", "Scalac"),
+    // "scrooge_java_library" -> Set("ScroogeRule", "Javac"),
+    // "thrift_library" -> Set("ScroogeRule")
   )
 
   private val forbiddenGenerators: Map[String, List[String]] = Map(


### PR DESCRIPTION
There is currently a small bug in Bloop which prevents Thrift support from working properly with large builds. We disable Thrift until a fix has been merged.