### PR TITLE
Exclude `java_avro_library`

### DIFF
--- a/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
+++ b/fastpass/src/main/scala/scala/meta/internal/fastpass/bazelbuild/BloopBazel.scala
@@ -491,7 +491,8 @@ object BloopBazel {
 
   private val forbiddenGenerators: Map[String, List[String]] = Map(
     "" -> List("create_datasets", "antlr"),
-    "scala_library" -> List("jvm_app")
+    "scala_library" -> List("jvm_app"),
+    "_java_library" -> List("java_avro_library")
   )
 
   private val forbiddenTags: List[String] = List(


### PR DESCRIPTION
Excluding targets of kind `java_avro_library` will cause bloop projects not to be built for them and they will be added to the dependency so that they will be built by the Bazel. 